### PR TITLE
 заменить lineSpacing на lineHeight в функции drawSeparators

### DIFF
--- a/src/components/hexview/src/qhexview.cpp
+++ b/src/components/hexview/src/qhexview.cpp
@@ -717,8 +717,8 @@ void QHexView::drawSeparators(QPainter* p) const {
 
     if(!m_options.hasFlag(QHexFlags::NoHeader) &&
        m_options.hasFlag(QHexFlags::HSeparator)) {
-        QLineF l(0, m_fontmetrics.lineSpacing(), this->lineWidth() - 1,
-                 m_fontmetrics.lineSpacing());
+        QLineF l(0, this->lineHeight(), this->lineWidth() - 1,
+         this->lineHeight());
         if(!m_hexdelegate || !m_hexdelegate->paintSeparator(p, l, this))
             p->drawLine(l);
     }


### PR DESCRIPTION
Исправляем проблему #33.

На Windows 11 QFontMetrics::lineSpacing() возвращает некорректное значение,
из-за чего горизонтальный сепаратор рисуется со смещением.

Для консистентности с остальной логикой отрисовки заменено на lineHeight(),
который используется в проекте как единый источник высоты строки.

Таким образом устраняется рассинхрон между текстом и линиями.