### PR TITLE
Фикс (fix #36)

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -114,13 +114,13 @@ target_link_libraries(${PROJECT_NAME} PRIVATE codeeditor)
 target_link_libraries(${PROJECT_NAME} PRIVATE hexview)
 
 target_link_libraries(${PROJECT_NAME} PRIVATE Qt${QT_VERSION_MAJOR}::Widgets)
-find_program(WINDEPLOYQT_EXECUTABLE windeployqt HINTS "${Qt6_DIR}/../../../bin")
+find_program(WINDEPLOYQT_EXECUTABLE windeployqt)
 
-if(WIN32 AND QT_VERSION_MAJOR EQUAL 6)
+if(WIN32 AND QT_VERSION_MAJOR EQUAL 6 AND WINDEPLOYQT_EXECUTABLE)
     add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
-        COMMAND "${CMAKE_PREFIX_PATH}/bin/windeployqt.exe"
+        COMMAND ${WINDEPLOYQT_EXECUTABLE}
                 $<TARGET_FILE:${PROJECT_NAME}>
-        COMMENT "Deploying Qt dependencies"
+        COMMENT "Deploying Qt dependencies with windeployqt"
     )
 endif()
 


### PR DESCRIPTION
Фикс #36

Собранный бинарник не запускался на системах без Qt или без Qt в PATH.

Решение: добавлен post-build шаг который автоматически запускает 
windeployqt после сборки — он копирует все нужные Qt DLL-ки и плагины 
рядом с exe-шником.

Что сделано:
- windeployqt ищется автоматически через find_program по пути Qt
- Запускается только на Windows при сборке с Qt6
- После сборки рядом с exe появляются все нужные зависимости

Проверено:
- Собрал проект локально
- Скопировал папку с exe на чистую систему без Qt в PATH
- Приложение запустилось без ошибок