### PR TITLE
Refactor: move project history saving logic to separate object #62

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,6 +62,9 @@ CMakeLists.txt.user*
 *.vcxproj
 *vcxproj.*
 
+# IDEA Clion generated files
+.idea
+
 # MinGW generated files
 *.Debug
 *.Release

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -65,6 +65,8 @@ if(${QT_VERSION_MAJOR} GREATER_EQUAL 6)
         core/ToolTab.h
         core/ToolTabFactory.cpp
         core/ToolTabFactory.h
+            utils/ProjectsHistoryManager.cpp
+            utils/ProjectsHistoryManager.h
 
 
     )

--- a/src/app/IDEWindow/idewindow.cpp
+++ b/src/app/IDEWindow/idewindow.cpp
@@ -5,9 +5,9 @@
 #include <qheaderview.h>
 #include <qjsondocument.h>
 #include <qjsonobject.h>
-#include <QStandardPaths>
 #include <QApplication>
 #include "globalwidgetsmanager.h"
+#include "projectshistorymanager.h"
 #include "app/WelcomeWindow/welcomeform.h"
 #include "dialogs/settingsdialog.h"
 #include "dialogs/reversecalculatordialog.h"
@@ -191,29 +191,8 @@ void IDEWindow::on_Open_ReverseCalculator()
     dlg->activateWindow();
 }
 
-void IDEWindow::SaveProjectInCache(const QString project_path){
-    QString dataDir = QStandardPaths::writableLocation(QStandardPaths::AppDataLocation);
-    QDir(dataDir).mkpath(".");
-    QFile history_file(dataDir+"/"+"history_open_projects.dat");
-    QStringList lines;
-    if (history_file.open(QIODevice::ReadOnly)) {
-        QByteArray data = history_file.readAll();
-        QString text = QString::fromUtf8(data);
-        lines = text.split(QRegularExpression("[\r\n]+"), Qt::SkipEmptyParts);
-        history_file.close();
-    }
-    lines.removeAll(project_path);
-    lines.prepend(project_path);
-    while (lines.size() > 15)
-        lines.removeLast();
-    if (!history_file.open(QIODevice::WriteOnly | QIODevice::Text)) return;
-    QTextStream out(&history_file);
-    for (const QString& l : lines){
-        if (!QDir(l).exists()) continue;
-        out << l << "\n";
-    }
-
-    history_file.close();
+void IDEWindow::SaveProjectInCache(const QString & project_path){
+    utils::ProjectsHistoryManager::saveProjectsHistory(project_path);
 }
 
 void IDEWindow::on_ClosingProject() {

--- a/src/app/IDEWindow/idewindow.h
+++ b/src/app/IDEWindow/idewindow.h
@@ -57,7 +57,7 @@ private:
     /**
      * @brief Сохранить текущий путь проекта в истории
     */
-    void SaveProjectInCache(const QString project_path);
+    void SaveProjectInCache(const QString& project_path);
 
     // - - Menu Bars - -
     QMenu* m_fileMenu;

--- a/src/app/WelcomeWindow/welcomeform.cpp
+++ b/src/app/WelcomeWindow/welcomeform.cpp
@@ -1,21 +1,19 @@
 #include "welcomeform.h"
 #include "app/IDEWindow/idewindow.h"
-#include "widgets/tooltabwidget.h"
 #include <qboxlayout.h>
 #include <qdir.h>
 #include <qlineedit.h>
-#include <qmessagebox.h>
 #include <qpushbutton.h>
 #include <QListView>
 #include <QFileDialog>
 #include <QStackedWidget>
 #include <QLabel>
 #include <QComboBox>
-#include <QJsonDocument>
-#include <QJsonObject>
 #include <QJsonArray>
 #include <qstandardpaths.h>
 #include <qstringlistmodel.h>
+
+#include "projectshistorymanager.h"
 
 WelcomeForm::WelcomeForm(QWidget *parent)
     : QWidget(parent)
@@ -229,25 +227,9 @@ void WelcomeForm::L2CreateProject(QString name, QString path, QString language){
 
 
 void WelcomeForm::SetProjectHistoryList(){
-    QString dataDir = QStandardPaths::writableLocation(QStandardPaths::AppDataLocation);
-    QDir(dataDir).mkpath(".");
-    QFile history_file(dataDir+"/"+"history_open_projects.dat");
-    QStringList lines;
-    if (history_file.open(QIODevice::ReadOnly)) {
-        QByteArray data = history_file.readAll();
-        QString text = QString::fromUtf8(data);
-        lines = text.split(QRegularExpression("[\r\n]+"), Qt::SkipEmptyParts);
-        history_file.close();
-    }
-
-    QStringList filtered;
-    for (const QString& l : lines) {
-        if (!QDir(l).exists()) continue;
-        filtered << l;
-    }
-    lines = filtered;
+    const QStringList history = utils::ProjectsHistoryManager::loadProjectsHistory();
 
     QStringListModel *model = new QStringListModel(this);
-    model->setStringList(lines);
+    model->setStringList(history);
     history_project_list->setModel(model);
 }

--- a/src/utils/projectshistorymanager.cpp
+++ b/src/utils/projectshistorymanager.cpp
@@ -1,0 +1,33 @@
+//
+// Created by Dmitriy on 3/27/26.
+//
+
+#include "projectshistorymanager.h"
+
+#include "filecontext.h"
+#include "filemanager.h"
+
+namespace utils {
+    QStringList ProjectsHistoryManager::loadProjectsHistory() {
+        FileContext fileContext(getDefaultPathLocation());
+        const QByteArray projectsHistory = FileManager::openFile(&fileContext);
+
+        return QString::fromUtf8(projectsHistory).split('\n');
+    }
+
+    void ProjectsHistoryManager::saveProjectsHistory(const QString &projectsHistory) {
+        QStringList projects = loadProjectsHistory();
+
+        projects.removeAll(projectsHistory);
+        projects.prepend(projectsHistory);
+
+        if (projects.size() > maxLength) projects = projects.mid(0, maxLength);
+
+        QByteArray data;
+
+        for (const QString & project : projects) data += project.toUtf8() + '\n';
+
+        FileContext fileContext(getDefaultPathLocation());
+        FileManager::saveFile(&fileContext, &data);
+    }
+} // utils

--- a/src/utils/projectshistorymanager.h
+++ b/src/utils/projectshistorymanager.h
@@ -1,0 +1,30 @@
+//
+// Created by Dmitriy on 3/27/26.
+//
+
+#ifndef CREMNIY_PROJECTS_HISTORY_MANAGER_H
+#define CREMNIY_PROJECTS_HISTORY_MANAGER_H
+#include <QStandardPaths>
+#include <QString>
+
+namespace utils {
+
+class ProjectsHistoryManager {
+
+private:
+    static constexpr unsigned short maxLength = 15;
+
+    static QString getDefaultPathLocation() {
+        return QStandardPaths::writableLocation(QStandardPaths::AppDataLocation) + "/history_open_projects.dat";
+    }
+
+    ProjectsHistoryManager() = default;
+
+public:
+    static QStringList loadProjectsHistory();
+    static void saveProjectsHistory(const QString & projectsHistory);
+};
+
+} // utils
+
+#endif //CREMNIY_PROJECTS_HISTORY_MANAGER_H


### PR DESCRIPTION
## Описание

Рефакторинг логики работы с историей проектов: вынес её в отдельный класс `ProjectsHistoryManager` и передал всю ответственность за работу с файлами существующему классу `FileManager`.

## Изменения

- Создан новый класс `utils::ProjectsHistoryManager`
- Класс отвечает за загрузку и сохранение списка недавно открытых проектов
- Операции чтения/записи файлов полностью делегированы существующему `FileManager` через `FileContext`
- Максимальная длина истории ограничена 15 записями