### PR TITLE
Fixing KDE Plasma issue with MenuBar: update idewindow.cpp

### DIFF
--- a/src/app/IDEWindow/idewindow.cpp
+++ b/src/app/IDEWindow/idewindow.cpp
@@ -20,6 +20,7 @@ IDEWindow::IDEWindow(QString ProjectPath, QWidget *parent)
     // - - Menu Bar - -
     MenuBarBuilder* menuBarBuilder = new MenuBarBuilder(menuBar(), this);
 
+    menuBar()->setNativeMenuBar(false);
     // - - Widgets - -
     m_statusBar = statusBar();
 


### PR DESCRIPTION
Fixed issue, when QMenuBar doesn't appear in KDE Plasma Window.

Before:
<img width="1076" height="524" alt="зображення" src="https://github.com/user-attachments/assets/c69c4189-f369-4cd7-949d-a4f2754cb824" />

Now:
<img width="1076" height="524" alt="зображення" src="https://github.com/user-attachments/assets/6fed89ee-f28d-427e-9c56-a4db950ff55b" />

Just added: `menuBar()->setNativeMenuBar(false);` in`idewindow.cpp`.