### PR TITLE
Clean/basic auto indent

### DIFF
--- a/src/libs/cremniy-codeeditor/src/widgets/CustomCodeEditor.cpp
+++ b/src/libs/cremniy-codeeditor/src/widgets/CustomCodeEditor.cpp
@@ -1385,7 +1385,13 @@ void CustomCodeEditor::keyPressEvent(QKeyEvent* event)
         endEditGrouping();
         if (kLogInputEvents)
             qDebug() << "[CustomCodeEditor][keyPressEvent] action=InsertNewline";
-        insertNewline();
+        if (shiftPressed) {
+            replaceRange(hasSelection() ? m_selectionStart : m_cursorBytePos,
+                         hasSelection() ? m_selectionLength : 0,
+                         QByteArray("\n"));
+        } else {
+            insertNewline();
+        }
         event->accept();
         return;
     case Qt::Key_Tab:
@@ -2678,6 +2684,8 @@ void CustomCodeEditor::insertNewline()
     const qint64 removeLength = hasSelection() ? m_selectionLength : 0;
     const qint64 lineNum = lineFromBytePos(insertPos);
     const QString lineText = displayTextForLine(lineNum);
+    const QString linePrefix = displayPrefixForPosition(lineNum, insertPos);
+    const QString lineSuffix = lineText.mid(linePrefix.length());
 
     QString indent;
     for (const QChar ch : lineText) {
@@ -2688,9 +2696,31 @@ void CustomCodeEditor::insertNewline()
         break;
     }
 
+    const QString indentUnit = m_tabReplace ? QString(m_tabReplaceSize, QLatin1Char(' '))
+                                            : QString(QLatin1Char('\t'));
+    const bool shouldIncreaseIndent = linePrefix.trimmed().endsWith(QLatin1Char('{'));
+    const bool splitClosingBrace = shouldIncreaseIndent && lineSuffix.trimmed().startsWith(QLatin1Char('}'));
+
     QByteArray replacement("\n");
     replacement.append(indent.toUtf8());
+    if (shouldIncreaseIndent)
+        replacement.append(indentUnit.toUtf8());
+    if (splitClosingBrace) {
+        replacement.append('\n');
+        replacement.append(indent.toUtf8());
+    }
+
     replaceRange(insertPos, removeLength, replacement);
+
+    if (splitClosingBrace) {
+        m_cursorBytePos = insertPos + 1 + indent.toUtf8().size() + indentUnit.toUtf8().size();
+        m_selectionStart = m_cursorBytePos;
+        m_selectionLength = 0;
+        m_selectionAnchor = -1;
+        syncSelectionToBuffer();
+        emit cursorPositionChanged();
+        viewport()->update();
+    }
 }
 
 void CustomCodeEditor::insertTab()
@@ -2766,6 +2796,28 @@ void CustomCodeEditor::insertText(const QString& text)
 {
     if (text.isEmpty())
         return;
+
+    if (text == QStringLiteral("{") && !hasSelection()) {
+        replaceRange(m_cursorBytePos, 0, QByteArray("{}"));
+        m_cursorBytePos = qMax<qint64>(firstTextByte(), m_cursorBytePos - 1);
+        m_selectionStart = m_cursorBytePos;
+        m_selectionLength = 0;
+        m_selectionAnchor = -1;
+        syncSelectionToBuffer();
+        emit cursorPositionChanged();
+        viewport()->update();
+        return;
+    }
+
+    if (text == QStringLiteral("}") && !hasSelection() && m_cursorBytePos < m_buffer->size() && m_buffer->getByte(m_cursorBytePos) == '}') {
+        ++m_cursorBytePos;
+        clearSelection();
+        ensureCursorVisible();
+        emit cursorPositionChanged();
+        viewport()->update();
+        return;
+    }
+
     replaceRange(hasSelection() ? m_selectionStart : m_cursorBytePos,
                  hasSelection() ? m_selectionLength : 0,
                  text.toUtf8());


### PR DESCRIPTION
## Summary

This PR improves basic editing ergonomics in the code editor by making newline indentation and brace insertion behave closer to modern IDEs.

## Changes

- preserve the current line indentation when pressing `Enter`
- add one extra indentation level after lines ending with `{`
- auto-insert matching `}` when typing `{`
- keep the caret between `{}` after auto-pair insertion
- when pressing `Enter` between `{}`:
  - split the braces onto separate lines
  - place the caret on the indented inner line
- make `Shift+Enter` insert a plain newline without smart indentation logic

## Example

Before:

```cpp
if (x) {|}
```

After pressing `Enter`:

```cpp
if (x) {
    |
}
```

Typing `{` now produces:

```cpp
{|}
```

## Testing

Tested manually in the code editor:
- `Enter` preserves indentation
- `{` auto-inserts `}`
- pressing `Enter` inside `{}` creates a properly indented block
- `Shift+Enter` inserts a plain newline without extra indentation