### PR TITLE
fix: prevent crash on project reopen by lazy-initializing TerminalWidget

### DIFF
--- a/src/app/IDEWindow/idewindow.cpp
+++ b/src/app/IDEWindow/idewindow.cpp
@@ -33,14 +33,16 @@ IDEWindow::IDEWindow(QString ProjectPath, QWidget *parent)
 
     m_verticalSplitter = new QSplitter(Qt::Vertical, m_mainWidget);
 
-    m_terminal = new TerminalWidget(this, ProjectPath);
-    m_terminal->setVisible(false);
+    // Terminal is initialized lazily on demand (see on_Toggle_Terminal)
+    // m_terminal = new TerminalWidget(this, ProjectPath);
+    // m_terminal->setVisible(false);
+    m_terminal = nullptr;
 
-    m_leftSidebar = new QWidget();
+    m_leftSidebar = new QWidget(this);
     QVBoxLayout* leftLayout = new QVBoxLayout(m_leftSidebar);
     leftLayout->setContentsMargins(0,0,0,0);
 
-    m_filesTabWidget = new FilesTabWidget();
+    m_filesTabWidget = new FilesTabWidget(this);
     m_filesTabWidget->setObjectName("filesTabWidget");
     m_filesTreeView = new FileTreeView();
     leftLayout->addWidget(m_filesTreeView);
@@ -50,7 +52,6 @@ IDEWindow::IDEWindow(QString ProjectPath, QWidget *parent)
     m_mainSplitter->setSizes({200, 1000});
 
     m_verticalSplitter->addWidget(m_mainSplitter); // Сверху все наше IDE
-    m_verticalSplitter->addWidget(m_terminal);     // Снизу терминал
     m_verticalSplitter->setSizes({800, 200});      // пр
 
     m_mainLayout->addWidget(m_verticalSplitter);
@@ -58,17 +59,15 @@ IDEWindow::IDEWindow(QString ProjectPath, QWidget *parent)
 
 
     // - - Tunning Widgets/Layouts - -
-
-    setCentralWidget(m_mainWidget);
-
-    m_mainLayout->addWidget(m_verticalSplitter);
-
     m_mainSplitter->setSizes({200, 1000});
     m_mainSplitter->setCollapsible(0, false);
     m_mainSplitter->setCollapsible(1, false);
 
     m_verticalSplitter->setSizes({800, 200});
+    
+    if (m_verticalSplitter->count() > 1) {
     m_verticalSplitter->setCollapsible(1, true);
+    }
 
     m_filesTreeView->setMinimumWidth(180);
     m_filesTreeView->setTextElideMode(Qt::ElideNone);
@@ -111,7 +110,18 @@ IDEWindow::~IDEWindow()
 {}
 
 void IDEWindow::on_Toggle_Terminal(bool checked) {
+    if (checked && !m_terminal) {
+        m_terminal = new TerminalWidget(this, m_projectPath);
+        m_verticalSplitter->addWidget(m_terminal);
+        m_verticalSplitter->setSizes({800, 200});
+    }
+
+    if (!m_terminal) {
+        return;
+    }
+
     m_terminal->setVisible(checked);
+
     if(checked) {
         m_terminal->setFocus();
     }


### PR DESCRIPTION
This PR fixes a crash / unstable behavior when reopening a project, especially on Linux/WSL.

### Root cause
TerminalWidget was being created in the IDEWindow constructor every time a project was opened. On Linux, this leads to issues with terminal/PTY reinitialization when reopening projects.

### Changes
- Removed eager initialization of TerminalWidget from IDEWindow constructor
- Introduced lazy initialization in on_Toggle_Terminal()
- TerminalWidget is now created only when explicitly needed
- Added safety checks for m_terminal usage
- Fixed QSplitter usage to avoid invalid index access

### Result
- Reopening projects no longer causes crashes or process stops on Linux/WSL
- Behavior remains unchanged on Windows

Closes #122 