### PR TITLE
Added KeyboardScanCode

### DIFF
--- a/src/ToolTabs/Binary/QHexView/src/qhexview.cpp
+++ b/src/ToolTabs/Binary/QHexView/src/qhexview.cpp
@@ -129,11 +129,7 @@ void QHexView::PaintContext::advanceX() { x += this->hexview->cellWidth(); }
 QHexView::QHexView(QWidget* parent)
     : QAbstractScrollArea(parent), m_fontmetrics(this->font()) {
     QFont f = QFontDatabase::systemFont(QFontDatabase::FixedFont);
-
-    if(f.styleHint() != QFont::TypeWriter) {
-        f.setFamily("Monospace"); // Force Monospaced font
-        f.setStyleHint(QFont::TypeWriter);
-    }
+    f.setStyleHint(QFont::Monospace);
 
     this->setFont(f);
     this->setMouseTracking(true);


### PR DESCRIPTION
**Меню**
В References → Keyboard Scan-Codes добавлен обработчик: открывается немодальное окно с WA_DeleteOnClose, родитель — главное окно IDE.

Диалог KeyboardScanCodesDialog
Краткое пояснение: IBM PC/AT scan code set 1 (make-коды в hex) и то, что native scan в Qt зависит от ОС/драйвера.
Область KeyCaptureFrame (пунктирная рамка): после клика по ней клавиши перехватываются здесь, не уходя в редактор.
Блок текущей клавиши: имя клавиши, Qt::Key, native scan, native virtual key, текст символа, модификаторы.
Таблица «Key / Set 1 make / Notes» — справочник по основным клавишам и расширенным (E0…) кодам.
Вертикальный сплиттер: таблица сверху, клавиатура снизу (с прокруткой при нехватке места).
Виджет KeyboardScanCodeVizWidget
Упрощённая US QWERTY + Win/Alt/Menu/Ctrl + нумпад + навигационный блок (Ins/Home/стрелки и т.д.).
На каждой клавише: подпись и hex Set 1 (для расширенных — вид E0 5B).
При нажатии подсвечиваются совпадающие по Qt::Key и флагу Keypad ячейки; при отпускании подсветка снимается.
Ограничение: у левого/правого Shift, Ctrl в Qt один и тот же Qt::Key, поэтому могут подсвечиваться обе подписи — это отражено в подсказке над зоной захвата.
Файлы
src/dialogs/keyboardscancodesdialog.{h,cpp} — диалог и рамка захвата клавиш.
src/widgets/keyboardscancodevizwidget.{h,cpp} — раскладка с подписями сканкодов.
Правки: referencesmenu.{h,cpp}, src/CMakeLists.txt.
Сборка: cmake --build /home/whoami/Projects/cremniy/src/build завершилась успешно.

**----------------------------------------------------------------------------------------------------------------------------------------**

**Menu**
A handler has been added to References → Keyboard Scan-Codes: a modeless window opens with WA_DeleteOnClose, the parent is the main IDE window.

KeyboardScanCodesDialog dialog
Brief explanation: IBM PC/AT scan code set 1 (makecodes in hex) and the fact that native scan in Qt depends on the OS/driver.
The KeyCaptureFrame area (dotted frame): after clicking on it, the keys are intercepted here without leaving the editor.
Current key block: key name, Qt::Key, native scan, native virtual key, character text, modifiers.
The "Key / Set 1 make / Notes" table is a reference for basic keys and extended (E0...) codes.
Vertical splitter: table on top, keyboard on the bottom (scrollable when space is tight).
KeyboardScanCodeVizWidget widget
Simplified US QWERTY + Win/Alt/Menu/Ctrl + numpad + navigation block (Ins/Home/arrows, etc.).
On each key: signature and hex Set 1 (for extended keys — type E0 5B).
When pressed, the cells that match the Qt::Key and the Keypad flag are highlighted; when released, the backlight is removed.
Limitation: the left/right Shift, Ctrl in Qt have the same Qt::Key, so both signatures can be highlighted — this is reflected in the tooltip above the capture area.

src/dialogs/keyboardscancodesdialog files.{h,cpp} — dialog and key capture frame.
src/widgets/keyboardscancodevizwidget.{h,cpp} — layout with scan code signatures.
Edits: referencesmenu.{h,cpp}, src/CMakeLists.txt .
Build: cmake --build /home/whoami/Projects/cremniy/src/build completed successfully.