### PR TITLE
Set Qt version lower bound (6.8.3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 [![Community](https://img.shields.io/badge/Community-Telegram-blue?logo=telegram&style=flat-square)](https://t.me/cremniy_com)
 <br>
 [![C++17](https://img.shields.io/badge/C%2B%2B-17-blue?style=flat-square&logo=cplusplus)](https://en.cppreference.com/w/cpp/17)
-[![Qt 6](https://img.shields.io/badge/Qt-6.4-41CD52?style=flat-square&logo=qt)](https://www.qt.io/)
+[![Qt 6](https://img.shields.io/badge/Qt-6.8.3-41CD52?style=flat-square&logo=qt)](https://www.qt.io/)
 
 English • [Русский](README_ru.md)
 
@@ -65,7 +65,7 @@ You constantly **switch** between different windows, and the tools are **not lin
 | Dependency | Minimum version |
 |---|---|
 | **CMake** | 3.16 |
-| **Qt** | 6.4 |
+| **Qt** | 6.8.3 |
 | **C++ compiler** | C++17 support |
 
 <details>

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 [![Community](https://img.shields.io/badge/Community-Telegram-blue?logo=telegram&style=flat-square)](https://t.me/cremniy_com)
 <br>
 [![C++17](https://img.shields.io/badge/C%2B%2B-17-blue?style=flat-square&logo=cplusplus)](https://en.cppreference.com/w/cpp/17)
-[![Qt 6](https://img.shields.io/badge/Qt-6.x-41CD52?style=flat-square&logo=qt)](https://www.qt.io/)
+[![Qt 6](https://img.shields.io/badge/Qt-6.4-41CD52?style=flat-square&logo=qt)](https://www.qt.io/)
 
 English • [Русский](README_ru.md)
 
@@ -65,7 +65,7 @@ You constantly **switch** between different windows, and the tools are **not lin
 | Dependency | Minimum version |
 |---|---|
 | **CMake** | 3.16 |
-| **Qt** | 6.x |
+| **Qt** | 6.4 |
 | **C++ compiler** | C++17 support |
 
 <details>

--- a/README_ru.md
+++ b/README_ru.md
@@ -11,7 +11,7 @@
 [![Community](https://img.shields.io/badge/Community-Telegram-blue?logo=telegram&style=flat-square)](https://t.me/cremniy_com)
 <br>
 [![C++17](https://img.shields.io/badge/C%2B%2B-17-blue?style=flat-square&logo=cplusplus)](https://en.cppreference.com/w/cpp/17)
-[![Qt 6](https://img.shields.io/badge/Qt-6.4-41CD52?style=flat-square&logo=qt)](https://www.qt.io/)
+[![Qt 6](https://img.shields.io/badge/Qt-6.8.3-41CD52?style=flat-square&logo=qt)](https://www.qt.io/)
 
 [English](README.md) • Русский
 
@@ -65,7 +65,7 @@
 | Зависимость | Мин. версия |
 |---|---|
 | **CMake** | 3.16 |
-| **Qt** | 6.4 |
+| **Qt** | 6.8.3 |
 | **Компилятор C++** | Поддержка C++17 |
 
 <details>

--- a/README_ru.md
+++ b/README_ru.md
@@ -11,7 +11,7 @@
 [![Community](https://img.shields.io/badge/Community-Telegram-blue?logo=telegram&style=flat-square)](https://t.me/cremniy_com)
 <br>
 [![C++17](https://img.shields.io/badge/C%2B%2B-17-blue?style=flat-square&logo=cplusplus)](https://en.cppreference.com/w/cpp/17)
-[![Qt 6](https://img.shields.io/badge/Qt-6.x-41CD52?style=flat-square&logo=qt)](https://www.qt.io/)
+[![Qt 6](https://img.shields.io/badge/Qt-6.4-41CD52?style=flat-square&logo=qt)](https://www.qt.io/)
 
 [English](README.md) • Русский
 
@@ -65,7 +65,7 @@
 | Зависимость | Мин. версия |
 |---|---|
 | **CMake** | 3.16 |
-| **Qt** | 6.x |
+| **Qt** | 6.4 |
 | **Компилятор C++** | Поддержка C++17 |
 
 <details>

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -9,7 +9,7 @@ set(CMAKE_AUTORCC ON)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-find_package(Qt6 6.4 REQUIRED COMPONENTS Widgets Test)
+find_package(Qt6 6.8.3 REQUIRED COMPONENTS Widgets Test)
 
 set(PROJECT_SOURCES
         main.cpp

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -9,99 +9,85 @@ set(CMAKE_AUTORCC ON)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-find_package(QT NAMES Qt6 Qt5 REQUIRED COMPONENTS Widgets Test)
-find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS Widgets Test)
+find_package(Qt6 6.4 REQUIRED COMPONENTS Widgets Test)
 
 set(PROJECT_SOURCES
         main.cpp
 )
 
-if(${QT_VERSION_MAJOR} GREATER_EQUAL 6)
-    qt_add_executable(${PROJECT_NAME}
-        MANUAL_FINALIZATION
-        main.cpp
+qt_add_executable(${PROJECT_NAME}
+    MANUAL_FINALIZATION
+    main.cpp
 
-        app/IDEWindow/idewindow.cpp
-        app/IDEWindow/idewindow.h
-        app/WelcomeWindow/welcomeform.cpp
-        app/WelcomeWindow/welcomeform.h
+    app/IDEWindow/idewindow.cpp
+    app/IDEWindow/idewindow.h
+    app/WelcomeWindow/welcomeform.cpp
+    app/WelcomeWindow/welcomeform.h
 
-        dialogs/filecreatedialog.cpp
-        dialogs/filecreatedialog.h
-        dialogs/settingsdialog.cpp
-        dialogs/settingsdialog.h
-        dialogs/reversecalculatordialog.cpp
-        dialogs/reversecalculatordialog.h
+    dialogs/filecreatedialog.cpp
+    dialogs/filecreatedialog.h
+    dialogs/settingsdialog.cpp
+    dialogs/settingsdialog.h
+    dialogs/reversecalculatordialog.cpp
+    dialogs/reversecalculatordialog.h
 
-        widgets/clickablelineedit.cpp
-        widgets/clickablelineedit.h
-        widgets/filetab.cpp
-        widgets/filetab.h
-        widgets/filetreeview.cpp
-        widgets/filetreeview.h
+    widgets/clickablelineedit.cpp
+    widgets/clickablelineedit.h
+    widgets/filetab.cpp
+    widgets/filetab.h
+    widgets/filetreeview.cpp
+    widgets/filetreeview.h
 
-        widgets/terminal/terminalwidget.cpp
-        widgets/terminal/terminalwidget.h
+    widgets/terminal/terminalwidget.cpp
+    widgets/terminal/terminalwidget.h
 
-        utils/iconprovider.cpp
-        utils/iconprovider.h
+    utils/iconprovider.cpp
+    utils/iconprovider.h
 
-        resources/cremniy_res.qrc
+    resources/cremniy_res.qrc
 
-        utils/utils.h
-        utils/utils.cpp
-        utils/appsettings.h
-        utils/appsettings.cpp
-        utils/instructionhelpservice.h
-        utils/instructionhelpservice.cpp
-        utils/filecontext.h
-        utils/filemanager.h
-        utils/filemanager.cpp
-        utils/projectshistorymanager.cpp
-        utils/projectshistorymanager.h
+    utils/utils.h
+    utils/utils.cpp
+    utils/appsettings.h
+    utils/appsettings.cpp
+    utils/instructionhelpservice.h
+    utils/instructionhelpservice.cpp
+    utils/filecontext.h
+    utils/filemanager.h
+    utils/filemanager.cpp
+    utils/projectshistorymanager.cpp
+    utils/projectshistorymanager.h
 
-        core/ToolTab.h
-        core/ToolTabFactory.cpp
-        core/ToolTabFactory.h
-        core/FileDataBuffer.h
-        core/FileDataBuffer.cpp
+    core/ToolTab.h
+    core/ToolTabFactory.cpp
+    core/ToolTabFactory.h
+    core/FileDataBuffer.h
+    core/FileDataBuffer.cpp
 
-        ui/MenuBar/menubarbuilder.h ui/MenuBar/menubarbuilder.cpp
-        ui/MenuBar/menufactory.h ui/MenuBar/menufactory.cpp
-        ui/MenuBar/Menus/File/filemenu.h ui/MenuBar/Menus/File/filemenu.cpp
-        ui/MenuBar/basemenu.h
-        ui/MenuBar/Menus/Edit/editmenu.h ui/MenuBar/Menus/Edit/editmenu.cpp
-        ui/MenuBar/Menus/View/viewmenu.h ui/MenuBar/Menus/View/viewmenu.cpp
-        ui/MenuBar/Menus/Build/buildmenu.h ui/MenuBar/Menus/Build/buildmenu.cpp
-        ui/MenuBar/Menus/Tools/toolsmenu.h ui/MenuBar/Menus/Tools/toolsmenu.cpp
-        ui/MenuBar/Menus/References/referencesmenu.h ui/MenuBar/Menus/References/referencesmenu.cpp
-        ui/filestabwidget.cpp
-        ui/filestabwidget.h
-        ui/toolstabwidget.cpp
-        ui/toolstabwidget.h
-
+    ui/MenuBar/menubarbuilder.h ui/MenuBar/menubarbuilder.cpp
+    ui/MenuBar/menufactory.h ui/MenuBar/menufactory.cpp
+    ui/MenuBar/Menus/File/filemenu.h ui/MenuBar/Menus/File/filemenu.cpp
+    ui/MenuBar/basemenu.h
+    ui/MenuBar/Menus/Edit/editmenu.h ui/MenuBar/Menus/Edit/editmenu.cpp
+    ui/MenuBar/Menus/View/viewmenu.h ui/MenuBar/Menus/View/viewmenu.cpp
+    ui/MenuBar/Menus/Build/buildmenu.h ui/MenuBar/Menus/Build/buildmenu.cpp
+    ui/MenuBar/Menus/Tools/toolsmenu.h ui/MenuBar/Menus/Tools/toolsmenu.cpp
+    ui/MenuBar/Menus/References/referencesmenu.h ui/MenuBar/Menus/References/referencesmenu.cpp
+    ui/filestabwidget.cpp
+    ui/filestabwidget.h
+    ui/toolstabwidget.cpp
+    ui/toolstabwidget.h
 
 
-    )
-    target_include_directories(${PROJECT_NAME} PRIVATE
-        ${CMAKE_CURRENT_SOURCE_DIR}
-        ${CMAKE_CURRENT_SOURCE_DIR}/widgets
-        ${CMAKE_CURRENT_SOURCE_DIR}/include
-        ${CMAKE_CURRENT_SOURCE_DIR}/utils
-        ${CMAKE_CURRENT_SOURCE_DIR}/ui
-        ${CMAKE_CURRENT_SOURCE_DIR}/terminal/ptyqt/core)
 
-else()
-    if(ANDROID)
-        add_library(${PROJECT_NAME} SHARED
-            ${PROJECT_SOURCES}
-        )
-    else()
-        add_executable(${PROJECT_NAME}
-            ${PROJECT_SOURCES}
-        )
-    endif()
-endif()
+)
+target_include_directories(${PROJECT_NAME} PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}
+    ${CMAKE_CURRENT_SOURCE_DIR}/widgets
+    ${CMAKE_CURRENT_SOURCE_DIR}/include
+    ${CMAKE_CURRENT_SOURCE_DIR}/utils
+    ${CMAKE_CURRENT_SOURCE_DIR}/ui
+    ${CMAKE_CURRENT_SOURCE_DIR}/terminal/ptyqt/core)
 
 
 # - - Tool Tabs - -
@@ -112,12 +98,11 @@ foreach(dir ${TOOLTAB_DIRS})
     endif()
 endforeach()
 
-target_link_libraries(${PROJECT_NAME} PRIVATE 
-    Qt${QT_VERSION_MAJOR}::Widgets
-)
+target_link_libraries(${PROJECT_NAME} PRIVATE Qt6::Widgets)
+
 find_program(WINDEPLOYQT_EXECUTABLE windeployqt)
 
-if(WIN32 AND QT_VERSION_MAJOR EQUAL 6 AND WINDEPLOYQT_EXECUTABLE)
+if(WIN32 AND WINDEPLOYQT_EXECUTABLE)
     add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
         COMMAND ${WINDEPLOYQT_EXECUTABLE}
                 $<TARGET_FILE:${PROJECT_NAME}>
@@ -125,9 +110,6 @@ if(WIN32 AND QT_VERSION_MAJOR EQUAL 6 AND WINDEPLOYQT_EXECUTABLE)
     )
 endif()
 
-if(${QT_VERSION} VERSION_LESS 6.1.0)
-  set(BUNDLE_ID_OPTION MACOSX_BUNDLE_GUI_IDENTIFIER com.example.${PROJECT_NAME})
-endif()
 set_target_properties(${PROJECT_NAME} PROPERTIES
     ${BUNDLE_ID_OPTION}
     MACOSX_BUNDLE_BUNDLE_VERSION ${PROJECT_VERSION}
@@ -143,6 +125,4 @@ install(TARGETS ${PROJECT_NAME}
     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
 )
 
-if(QT_VERSION_MAJOR EQUAL 6)
-    qt_finalize_executable(${PROJECT_NAME})
-endif()
+qt_finalize_executable(${PROJECT_NAME})

--- a/src/ToolTabs/Binary/QHexView/CMakeLists.txt
+++ b/src/ToolTabs/Binary/QHexView/CMakeLists.txt
@@ -2,18 +2,7 @@ cmake_minimum_required(VERSION 3.13)
 
 project(QHexView)
 
-option(QHEXVIEW_USE_QT5 "Enable Qt5 build" OFF)
 option(QHEXVIEW_ENABLE_DIALOGS "BuiltIn dialogs" ON)
-
-if(QHEXVIEW_USE_QT5)
-    find_package(Qt5 REQUIRED COMPONENTS Widgets)
-else()
-    find_package(Qt6 COMPONENTS Widgets)
-
-    if(NOT Qt6_FOUND)
-        find_package(Qt5 REQUIRED COMPONENTS Widgets)
-    endif()
-endif()
 
 add_library(${PROJECT_NAME} STATIC)
 
@@ -24,10 +13,7 @@ set_target_properties(${PROJECT_NAME}
         AUTOMOC ON
 )
 
-target_link_libraries(${PROJECT_NAME}
-    PUBLIC
-        Qt::Widgets
-)
+target_link_libraries(${PROJECT_NAME} PUBLIC Qt6::Widgets)
 
 target_sources(${PROJECT_NAME}
     PRIVATE 

--- a/src/ToolTabs/Binary/QHexView/CMakeLists.txt
+++ b/src/ToolTabs/Binary/QHexView/CMakeLists.txt
@@ -1,5 +1,3 @@
-cmake_minimum_required(VERSION 3.13)
-
 project(QHexView)
 
 option(QHEXVIEW_ENABLE_DIALOGS "BuiltIn dialogs" ON)

--- a/src/ToolTabs/Binary/QHexView/README.md
+++ b/src/ToolTabs/Binary/QHexView/README.md
@@ -2,7 +2,7 @@
  <img src="https://user-images.githubusercontent.com/1503603/156148159-02d1181a-153e-4d0b-9512-5f9ac30bcd2f.png" alt="QHexView logo" title="QHexView"/>
 </div>
 <div align="center">
- <i>An hexadecimal widget for Qt5 and Qt6</i>
+ <i>An hexadecimal widget for Qt6</i>
  <br>
  <br>
  <div align="center">


### PR DESCRIPTION
When I tried to build `cremniy` for the first time, I stumbled upon the issue:
```
[ 53%] Building CXX object CMakeFiles/cremniy.dir/dialogs/reversecalculatordialog.cpp.o
cremniy/src/dialogs/reversecalculatordialog.cpp: In member function ‘void ReverseCalculatorDialog::onInputChanged()’:
cremniy/src/dialogs/reversecalculatordialog.cpp:227:13: error: ‘class QFormLayout’ has no member named ‘setRowVisible’
  227 |     m_form->setRowVisible(m_decS, true);
      |             ^~~~~~~~~~~~~
cremniy/src/dialogs/reversecalculatordialog.cpp:233:13: error: ‘class QFormLayout’ has no member named ‘setRowVisible’
  233 |     m_form->setRowVisible(m_decS, false);
      |             ^~~~~~~~~~~~~
gmake[2]: *** [CMakeFiles/cremniy.dir/build.make:173: CMakeFiles/cremniy.dir/dialogs/reversecalculatordialog.cpp.o] Error 1
gmake[1]: *** [CMakeFiles/Makefile2:243: CMakeFiles/cremniy.dir/all] Error 2
gmake: *** [Makefile:136: all] Error 2
```

It turns out that function `setRowVisible` (usages [first](https://github.com/munirov/cremniy/blob/71bb531a81bdd513f3c4f8b5f088cc3840e00a9b/src/dialogs/reversecalculatordialog.cpp#L227), [second](https://github.com/munirov/cremniy/blob/71bb531a81bdd513f3c4f8b5f088cc3840e00a9b/src/dialogs/reversecalculatordialog.cpp#L233))
was introduced in Qt 6.4 ([docs](https://doc.qt.io/qt-6/qformlayout.html#setRowVisible-2)),

whilst I had a Qt 6.2.4 (`qt6-base-dev/jammy-updates,now 6.2.4`, standard for Ubuntu 22.04).

---

To prevent further build errors in case of insufficient Qt version,
I set lower bound for Qt to 6.4 since we need it anyway due to recently used  `setRowVisible` function.

---

Therefore I removed Qt5 option (currently [unused](https://github.com/munirov/cremniy/blob/71bb531a81bdd513f3c4f8b5f088cc3840e00a9b/src/ToolTabs/Binary/QHexView/CMakeLists.txt#L5)) in QHexView imported module.

Consider I preserved dependencies and other possible version conventions,
because we already point out in README that [we use Qt 6.x](https://github.com/munirov/cremniy/blob/71bb531a81bdd513f3c4f8b5f088cc3840e00a9b/README.md?plain=1#L68)