### PR TITLE
Status bar

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -106,7 +106,10 @@ add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/libs/cremniy-codeeditor ${CMAKE_BIN
 add_subdirectory(ToolTabs/always)
 add_subdirectory(ToolTabs/other)
 
-target_link_libraries(${PROJECT_NAME} PRIVATE Qt6::Widgets)
+target_link_libraries(${PROJECT_NAME} PRIVATE
+    Qt6::Widgets
+    cremniy-codeeditor
+)
 
 find_program(WINDEPLOYQT_EXECUTABLE windeployqt)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -90,6 +90,7 @@ qt_add_executable(${PROJECT_NAME}
 
 target_include_directories(${PROJECT_NAME} PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/libs/cremniy-codeeditor/include
+    ${CMAKE_CURRENT_SOURCE_DIR}/libs/cremniy-codeeditor/third_party/QCodeEditor/include
     ${CMAKE_CURRENT_SOURCE_DIR}
     ${CMAKE_CURRENT_SOURCE_DIR}/widgets
     ${CMAKE_CURRENT_SOURCE_DIR}/include

--- a/src/ToolTabs/always/Binary/FormatPages/RAW/rawpage.cpp
+++ b/src/ToolTabs/always/Binary/FormatPages/RAW/rawpage.cpp
@@ -64,6 +64,54 @@ RAWPage::RAWPage(QWidget *parent)
 
 }
 
+qint64 RAWPage::currentOffset() const
+{
+    return m_hexViewWidget->hexCursor()->offset();
+}
+
+qint64 RAWPage::currentSelectionStartOffset() const
+{
+    return m_hexViewWidget->hexCursor()->selectionStartOffset();
+}
+
+qint64 RAWPage::currentSelectionLength() const
+{
+    return m_hexViewWidget->hexCursor()->selectionLength();
+}
+
+qint64 RAWPage::dataSize() const
+{
+    if (m_sharedBuffer)
+        return m_sharedBuffer->size();
+
+    return m_hexViewWidget->getBData().size();
+}
+
+ToolStatusState RAWPage::statusState() const
+{
+    const qint64 size = dataSize();
+    if (size <= 0) {
+        return {"No data", "", "RAW"};
+    }
+
+    qint64 offset = currentOffset();
+    if (currentSelectionLength() > 0) {
+        offset = currentSelectionStartOffset();
+    }
+
+    offset = qBound<qint64>(0, offset, size - 1);
+
+    const QString address = QString("0x%1")
+        .arg(static_cast<qulonglong>(offset), 0, 16)
+        .toUpper();
+
+    return {
+        QString("Address %1").arg(address),
+        QString("Byte %1").arg(offset + 1),
+        "RAW"
+    };
+}
+
 void RAWPage::setPageData(QByteArray& data) {
     m_sharedBuffer = nullptr;
     m_hexViewWidget->setBData(data);
@@ -101,4 +149,3 @@ void RAWPage::setSharedBuffer(FileDataBuffer* buffer)
     m_dataHash = buffer->currentHash();
     emit dataEqual();
 }
-

--- a/src/ToolTabs/always/Binary/FormatPages/RAW/rawpage.h
+++ b/src/ToolTabs/always/Binary/FormatPages/RAW/rawpage.h
@@ -14,6 +14,11 @@ public:
     explicit RAWPage(QWidget *parent = nullptr);
 
     QString pageName() const override { return "RAW"; }
+    ToolStatusState statusState() const override;
+    qint64 currentOffset() const;
+    qint64 currentSelectionStartOffset() const;
+    qint64 currentSelectionLength() const;
+    qint64 dataSize() const;
 
     void setPageData(QByteArray& data) override;
     QByteArray getPageData() const override;

--- a/src/ToolTabs/always/Binary/binarytab.cpp
+++ b/src/ToolTabs/always/Binary/binarytab.cpp
@@ -26,6 +26,14 @@ void syncCurrentFormatPage(QStackedWidget* pageView, FileDataBuffer* dataBuffer)
 
     currentPage->setSharedBuffer(dataBuffer);
 }
+
+FormatPage* currentFormatPage(QStackedWidget* pageView)
+{
+    if (!pageView)
+        return nullptr;
+
+    return dynamic_cast<FormatPage*>(pageView->currentWidget());
+}
 }
 
 BinaryTab::BinaryTab(FileDataBuffer* buffer, QWidget *parent)
@@ -79,6 +87,8 @@ BinaryTab::BinaryTab(FileDataBuffer* buffer, QWidget *parent)
                             setModifyIndicator(false);
                             emit dataEqual();
                         }
+
+                        updateStatusState();
                     });
             
             // Подключаем сигнал выделения от страницы к буферу
@@ -89,6 +99,8 @@ BinaryTab::BinaryTab(FileDataBuffer* buffer, QWidget *parent)
                         m_updatingSelection = true;
                         m_dataBuffer->setSelection(pos, length);
                         m_updatingSelection = false;
+
+                        updateStatusState();
                     });
         }
     }
@@ -107,6 +119,7 @@ BinaryTab::BinaryTab(FileDataBuffer* buffer, QWidget *parent)
                 if (row >= 0)
                     syncCurrentFormatPage(pageView, m_dataBuffer);
                 m_pageDataDirty = false;
+                updateStatusState();
             });
 
     m_findShortcut = new QShortcut(QKeySequence::Find, this);
@@ -114,6 +127,8 @@ BinaryTab::BinaryTab(FileDataBuffer* buffer, QWidget *parent)
 
     connect(m_dataBuffer, &FileDataBuffer::selectionChanged,
             this, &BinaryTab::onSelectionChanged);
+
+    updateStatusState();
 }
 
 
@@ -150,6 +165,8 @@ void BinaryTab::setTabData(){
         emit dataEqual();
     }
     qDebug() << "HexViewTab: setTabData(): success";
+
+    updateStatusState();
 };
 
 void BinaryTab::onDataChanged()
@@ -176,6 +193,7 @@ void BinaryTab::onSelectionChanged(qint64 pos, qint64 length)
     }
     
     m_updatingSelection = false;
+    updateStatusState();
 }
 
 void BinaryTab::saveTabData() {
@@ -190,6 +208,17 @@ void BinaryTab::saveTabData() {
     setModifyIndicator(false);
     emit dataEqual();
     emit refreshDataAllTabsSignal();
+}
+
+void BinaryTab::updateStatusState()
+{
+    auto* page = currentFormatPage(pageView);
+    if (!page) {
+        setStatusState({"Binary", "", ""});
+        return;
+    }
+
+    setStatusState(page->statusState());
 }
 
 void BinaryTab::openFindDialog()

--- a/src/ToolTabs/always/Binary/binarytab.cpp
+++ b/src/ToolTabs/always/Binary/binarytab.cpp
@@ -125,9 +125,6 @@ BinaryTab::BinaryTab(FileDataBuffer* buffer, QWidget *parent)
     m_findShortcut = new QShortcut(QKeySequence::Find, this);
     connect(m_findShortcut, &QShortcut::activated, this, &BinaryTab::openFindDialog);
 
-    connect(m_dataBuffer, &FileDataBuffer::selectionChanged,
-            this, &BinaryTab::onSelectionChanged);
-
     updateStatusState();
 }
 

--- a/src/ToolTabs/always/Binary/binarytab.h
+++ b/src/ToolTabs/always/Binary/binarytab.h
@@ -21,6 +21,7 @@ private:
     QShortcut* m_findShortcut = nullptr;
 
     void openFindDialog();
+    void updateStatusState();
 
 protected slots:
     // Обработчик изменения выделения из буфера

--- a/src/ToolTabs/always/Binary/formatpage.cpp
+++ b/src/ToolTabs/always/Binary/formatpage.cpp
@@ -5,6 +5,15 @@
 // чтобы Qt создал vtable для FormatPage
 FormatPage::~FormatPage() {}
 
+ToolStatusState FormatPage::statusState() const
+{
+    return {
+        QString("Page %1").arg(pageName()),
+        "",
+        "Binary"
+    };
+}
+
 void FormatPage::setSharedBuffer(FileDataBuffer* buffer)
 {
     m_sharedBuffer = buffer;

--- a/src/ToolTabs/always/Binary/formatpage.h
+++ b/src/ToolTabs/always/Binary/formatpage.h
@@ -1,6 +1,7 @@
 #ifndef FORMATPAGE_H
 #define FORMATPAGE_H
 
+#include "core/ToolStatusState.h"
 #include <QWidget>
 #include <qboxlayout.h>
 
@@ -19,6 +20,7 @@ public:
     ~FormatPage();
 
     virtual QString pageName() const = 0;
+    virtual ToolStatusState statusState() const;
 
     virtual void setPageData(QByteArray& data) = 0;
     virtual QByteArray getPageData() const = 0;

--- a/src/ToolTabs/always/CodeEditor/codeeditortab.cpp
+++ b/src/ToolTabs/always/CodeEditor/codeeditortab.cpp
@@ -124,6 +124,8 @@ CodeEditorTab::CodeEditorTab(FileDataBuffer* buffer, QWidget* parent)
             emit dataEqual();
     });
 
+    connect(m_codeEditorWidget, &CustomCodeEditor::cursorPositionChanged, this, &CodeEditorTab::updateStatusState);
+
     m_findShortcut = new QShortcut(QKeySequence::Find, this);
     m_replaceShortcut = new QShortcut(QKeySequence::Replace, this);
     m_findNextShortcut = new QShortcut(QKeySequence(Qt::Key_F3), this);
@@ -135,6 +137,8 @@ CodeEditorTab::CodeEditorTab(FileDataBuffer* buffer, QWidget* parent)
     connect(m_findNextShortcut, &QShortcut::activated, this, [this]() { findNext(true); });
     connect(m_findPreviousShortcut, &QShortcut::activated, this, [this]() { findNext(false); });
     connect(m_goToLineShortcut, &QShortcut::activated, this, &CodeEditorTab::openGoToLineDialog);
+
+    updateStatusState();
 }
 
 void CodeEditorTab::openFindDialog()
@@ -239,12 +243,14 @@ void CodeEditorTab::closeSearchBar()
 {
     m_searchBar->hide();
     m_codeEditorWidget->setFocus();
+    updateStatusState();
 }
 
 void CodeEditorTab::setFile(QString filepath)
 {
     m_fileContext = new FileContext(filepath);
     m_codeEditorWidget->setFileExt(CustomCodeEditor::syntaxKeyForPath(filepath));
+    updateStatusState();
 }
 
 void CodeEditorTab::setTabData()
@@ -286,6 +292,8 @@ void CodeEditorTab::setTabData()
         emit dataEqual();
         qDebug() << "CodeEditorTab::setTabData dataEqual returned this=" << this;
     }
+
+    updateStatusState();
 }
 
 void CodeEditorTab::onDataChanged()
@@ -305,6 +313,26 @@ void CodeEditorTab::onSelectionChanged(qint64 pos, qint64 length)
     Q_UNUSED(length);
     if (m_updatingSelection)
         return;
+}
+
+void CodeEditorTab::updateStatusState()
+{
+    if (!m_overlayWidget->isHidden()) {
+        setStatusState({"Binary file detected", "", m_codeEditorWidget->syntaxKey().toUpper()});
+        return;
+    }
+
+    const qint64 line = m_codeEditorWidget->cursorLineNumber();
+    const qint64 column = m_codeEditorWidget->cursorColumnNumber();
+    const QString syntax = m_codeEditorWidget->syntaxKey().isEmpty()
+        ? QStringLiteral("TEXT")
+        : m_codeEditorWidget->syntaxKey().toUpper();
+
+    setStatusState({
+        QString("Line %1").arg(line),
+        QString("Column %1").arg(column),
+        syntax
+    });
 }
 
 void CodeEditorTab::saveTabData()

--- a/src/ToolTabs/always/CodeEditor/codeeditortab.h
+++ b/src/ToolTabs/always/CodeEditor/codeeditortab.h
@@ -55,6 +55,7 @@ private:
     void openReplaceDialog();
     void findNext(bool forward = true);
     void openGoToLineDialog();
+    void updateStatusState();
     void updateSearchUi();
     void setReplaceMode(bool enabled);
     void replaceCurrent();

--- a/src/ToolTabs/other/Disassembler/disassemblertab.cpp
+++ b/src/ToolTabs/other/Disassembler/disassemblertab.cpp
@@ -258,6 +258,7 @@ DisassemblerTab::DisassemblerTab(FileDataBuffer* buffer, QWidget *parent)
             // this, &DisassemblerTab::onGlobalActionTriggered);
 
     updateBackendUiHint();
+    updateStatusState();
 }
 
 DisassemblerTab::~DisassemblerTab()
@@ -269,6 +270,7 @@ DisassemblerTab::~DisassemblerTab()
 
 void DisassemblerTab::setFile(QString filepath){
     m_fileContext = new FileContext(filepath);
+    updateStatusState();
 }
 
 void DisassemblerTab::setTabData()
@@ -328,6 +330,7 @@ void DisassemblerTab::onSelectionChanged(qint64 pos, qint64 length)
     }
 
     m_updatingSelection = false;
+    updateStatusState();
 }
 
 void DisassemblerTab::onDataChanged()
@@ -482,6 +485,7 @@ void DisassemblerTab::setupUi()
     m_disasmView->viewport()->installEventFilter(this);
     m_disasmHighlighter = new DisasmTextHighlighter(m_disasmView->document());
     connect(m_disasmView, &QPlainTextEdit::cursorPositionChanged, this, [this]() {
+        updateStatusState();
         if (!m_disasmView || !m_disasmView->hasFocus())
             return;
         const QPoint p = m_disasmView->cursorRect().bottomRight();
@@ -490,6 +494,7 @@ void DisassemblerTab::setupUi()
 
     // Обработчик выделения в дизассемблере - уведомляем буфер
     connect(m_disasmView, &QPlainTextEdit::selectionChanged, this, [this]() {
+        updateStatusState();
         if (m_updatingSelection) return; // Предотвращаем рекурсию
         
         QTextCursor cursor = m_disasmView->textCursor();
@@ -837,6 +842,67 @@ void DisassemblerTab::showInstructionHelpAt(const QPoint &pos, bool forceByCurso
     QToolTip::showText(globalPos, tip, m_disasmView->viewport());
 }
 
+const DisassemblerTab::LineInfo *DisassemblerTab::currentLineInfo(int *visibleLine) const
+{
+    if (!m_disasmView)
+        return nullptr;
+
+    const int currentVisibleLine = m_disasmView->textCursor().blockNumber();
+    if (visibleLine)
+        *visibleLine = currentVisibleLine;
+
+    if (currentVisibleLine < 0 || currentVisibleLine >= m_visibleLineMap.size())
+        return nullptr;
+
+    const int lineIndex = m_visibleLineMap[currentVisibleLine];
+    if (lineIndex < 0 || lineIndex >= m_lines.size())
+        return nullptr;
+
+    return &m_lines[lineIndex];
+}
+
+int DisassemblerTab::currentInstructionOrdinal(int visibleLine) const
+{
+    if (visibleLine < 0 || visibleLine >= m_visibleLineMap.size())
+        return 0;
+
+    int ordinal = 0;
+    for (int i = 0; i <= visibleLine; ++i) {
+        const int lineIndex = m_visibleLineMap[i];
+        if (lineIndex >= 0 && lineIndex < m_lines.size())
+            ++ordinal;
+    }
+
+    return ordinal;
+}
+
+void DisassemblerTab::updateStatusState()
+{
+    if (m_running) {
+        setStatusState({"Disassembling…", "", "Disassembler"});
+        return;
+    }
+
+    int visibleLine = -1;
+    const LineInfo *lineInfo = currentLineInfo(&visibleLine);
+    if (!lineInfo) {
+        setStatusState({"No instruction selected", "", "Disassembler"});
+        return;
+    }
+
+    const QString address = lineInfo->address.trimmed().isEmpty()
+        ? QStringLiteral("Unknown")
+        : lineInfo->address.trimmed();
+
+    const int instructionIndex = currentInstructionOrdinal(visibleLine);
+
+    setStatusState({
+        QString("Address %1").arg(address),
+        instructionIndex > 0 ? QString("Instruction %1").arg(instructionIndex) : QString(),
+        "Disassembler"
+    });
+}
+
 void DisassemblerTab::updateBackendUiHint()
 {
     if (m_running) return;
@@ -911,6 +977,7 @@ void DisassemblerTab::startDisassembly()
 
     setRunningState(true);
     showPlaceholder(tr("Disassembling…"));
+    updateStatusState();
 
     emit requestDisassembly(m_fileContext->filePath(), {});
 }
@@ -974,6 +1041,7 @@ void DisassemblerTab::onSectionFound(const DisasmSection &section)
     for (const auto &s : m_sections) total += s.instructions.size();
     m_statusLabel->setText(
         tr("%1 section(s) · %2 instructions loaded…").arg(m_sections.size()).arg(total));
+    updateStatusState();
 }
 
 void DisassemblerTab::onFunctionsFound(const QVector<DisasmFunction> &funcs)
@@ -1080,10 +1148,12 @@ void DisassemblerTab::jumpToAddress(const QString &addr)
             sel.cursor = cursor;
             extra.append(sel);
             m_disasmView->setExtraSelections(extra);
+            updateStatusState();
         }
     } else {
         // Если адрес не найден (например, он в другой секции, которая сейчас скрыта фильтром)
         m_statusLabel->setText(tr("Address %1 is not visible in current view").arg(addr));
+        updateStatusState();
     }
 }
 
@@ -1100,6 +1170,7 @@ void DisassemblerTab::onWorkerFinished()
                "Make sure the file is a supported binary (ELF, PE, Mach-O…)\n"
                "Check the Log panel for details."));
         m_statusLabel->clear();
+        updateStatusState();
         return;
     }
 
@@ -1114,6 +1185,8 @@ void DisassemblerTab::onWorkerFinished()
     // If backend didn't provide functions (objdump), derive from labels.
     if (m_functions.isEmpty())
         rebuildFunctionsFromLines();
+
+    updateStatusState();
 }
 
 void DisassemblerTab::onWorkerError(const QString &msg)
@@ -1123,6 +1196,7 @@ void DisassemblerTab::onWorkerError(const QString &msg)
     appendLog("[ERROR] " + msg);
     showPlaceholder(tr("objdump error — see Log panel for details"));
     m_statusLabel->setText(tr("Error"));
+    updateStatusState();
 }
 
 void DisassemblerTab::onProgressUpdated(int percent)
@@ -1142,6 +1216,7 @@ void DisassemblerTab::showPlaceholder(const QString &msg)
 {
     m_placeholderLbl->setText(msg);
     m_stack->setCurrentWidget(m_placeholderLbl);
+    updateStatusState();
 }
 
 void DisassemblerTab::populateSectionCombo()
@@ -1260,6 +1335,7 @@ void DisassemblerTab::applyFilter()
     }
     
     m_statusLabel->setText(tr("%1 lines shown").arg(shownLines));
+    updateStatusState();
 }
 
 #include "moc_disassemblertab.cpp"

--- a/src/ToolTabs/other/Disassembler/disassemblertab.cpp
+++ b/src/ToolTabs/other/Disassembler/disassemblertab.cpp
@@ -878,15 +878,42 @@ int DisassemblerTab::currentInstructionOrdinal(int visibleLine) const
 
 void DisassemblerTab::updateStatusState()
 {
-    if (m_running) {
+    if (m_statusMode == StatusMode::Loading || m_running) {
         setStatusState({"Disassembling…", "", "Disassembler"});
+        return;
+    }
+
+    if (m_statusMode == StatusMode::Idle) {
+        setStatusState({"Ready to disassemble", "", "Disassembler"});
+        return;
+    }
+
+    if (m_statusMode == StatusMode::Error) {
+        setStatusState({
+            m_statusDetail.isEmpty() ? QStringLiteral("Disassembly failed") : m_statusDetail,
+            QString(),
+            QStringLiteral("Disassembler")
+        });
+        return;
+    }
+
+    if (m_statusMode == StatusMode::Empty) {
+        setStatusState({
+            m_statusDetail.isEmpty() ? QStringLiteral("No disassembly results") : m_statusDetail,
+            QString(),
+            QStringLiteral("Disassembler")
+        });
         return;
     }
 
     int visibleLine = -1;
     const LineInfo *lineInfo = currentLineInfo(&visibleLine);
     if (!lineInfo) {
-        setStatusState({"No instruction selected", "", "Disassembler"});
+        setStatusState({
+            m_statusDetail.isEmpty() ? QStringLiteral("No instruction selected") : m_statusDetail,
+            QString(),
+            QStringLiteral("Disassembler")
+        });
         return;
     }
 
@@ -921,7 +948,12 @@ void DisassemblerTab::onGlobalActionTriggered(const QString &actionName)
 void DisassemblerTab::startDisassembly()
 {
     if (m_running) return;
-    if (m_fileContext->filePath().isEmpty()) { showPlaceholder(tr("No file path set")); return; }
+    if (m_fileContext->filePath().isEmpty()) {
+        m_statusMode = StatusMode::Error;
+        m_statusDetail = QStringLiteral("No file path set");
+        showPlaceholder(tr("No file path set"));
+        return;
+    }
 
     // If radare2 backend is selected, ensure r2 is available. If not, prompt for path.
     if (AppSettings::disasmBackend() == AppSettings::DisasmBackend::Radare2) {
@@ -936,6 +968,8 @@ void DisassemblerTab::startDisassembly()
                 QString());
             if (picked.isEmpty()) {
                 appendLog("[disasm] radare2 not configured; cancelled");
+                m_statusMode = StatusMode::Error;
+                m_statusDetail = QStringLiteral("radare2 is not configured");
                 showPlaceholder(tr("radare2 is not configured — set it in Settings"));
                 return;
             }
@@ -976,6 +1010,8 @@ void DisassemblerTab::startDisassembly()
                   .arg(AppSettings::disasmBackend() == AppSettings::DisasmBackend::Radare2 ? "radare2" : "objdump"));
 
     setRunningState(true);
+    m_statusMode = StatusMode::Loading;
+    m_statusDetail.clear();
     showPlaceholder(tr("Disassembling…"));
     updateStatusState();
 
@@ -1039,6 +1075,8 @@ void DisassemblerTab::onSectionFound(const DisasmSection &section)
 
     int total = 0;
     for (const auto &s : m_sections) total += s.instructions.size();
+    m_statusMode = StatusMode::Ready;
+    m_statusDetail = tr("%1 instructions").arg(total);
     m_statusLabel->setText(
         tr("%1 section(s) · %2 instructions loaded…").arg(m_sections.size()).arg(total));
     updateStatusState();
@@ -1153,6 +1191,7 @@ void DisassemblerTab::jumpToAddress(const QString &addr)
     } else {
         // Если адрес не найден (например, он в другой секции, которая сейчас скрыта фильтром)
         m_statusLabel->setText(tr("Address %1 is not visible in current view").arg(addr));
+        m_statusDetail = tr("Address %1 is not visible").arg(addr);
         updateStatusState();
     }
 }
@@ -1165,6 +1204,8 @@ void DisassemblerTab::onWorkerFinished()
     appendLog("=== Disassembly finished ===");
 
     if (m_sections.isEmpty()) {
+        m_statusMode = StatusMode::Empty;
+        m_statusDetail = QStringLiteral("No disassemblable sections found");
         showPlaceholder(
             tr("No disassemblable sections found.\n"
                "Make sure the file is a supported binary (ELF, PE, Mach-O…)\n"
@@ -1176,6 +1217,8 @@ void DisassemblerTab::onWorkerFinished()
 
     int total = 0;
     for (const auto &s : m_sections) total += s.instructions.size();
+    m_statusMode = StatusMode::Ready;
+    m_statusDetail = tr("%1 instructions").arg(total);
     m_statusLabel->setText(
         tr("%1 section(s) · %2 instructions").arg(m_sections.size()).arg(total));
 
@@ -1194,6 +1237,8 @@ void DisassemblerTab::onWorkerError(const QString &msg)
     setRunningState(false);
     m_progressBar->setVisible(false);
     appendLog("[ERROR] " + msg);
+    m_statusMode = StatusMode::Error;
+    m_statusDetail = msg.isEmpty() ? QStringLiteral("Disassembly failed") : msg;
     showPlaceholder(tr("objdump error — see Log panel for details"));
     m_statusLabel->setText(tr("Error"));
     updateStatusState();
@@ -1329,8 +1374,16 @@ void DisassemblerTab::applyFilter()
     m_disasmView->setPlainText(out.join('\n'));
 
     if (shownLines == 0 && haveQuery) {
+        m_statusMode = StatusMode::Empty;
+        m_statusDetail = tr("No results for \"%1\"").arg(m_searchEdit->text());
         showPlaceholder(tr("No results for \"%1\"").arg(m_searchEdit->text()));
     } else {
+        m_statusMode = m_sections.isEmpty() ? StatusMode::Empty : StatusMode::Ready;
+        if (!haveQuery) {
+            m_statusDetail = tr("%1 instructions").arg(shownLines);
+        } else {
+            m_statusDetail = tr("%1 filtered instructions").arg(shownLines);
+        }
         m_stack->setCurrentWidget(m_topSplitter);
     }
     

--- a/src/ToolTabs/other/Disassembler/disassemblertab.h
+++ b/src/ToolTabs/other/Disassembler/disassemblertab.h
@@ -85,6 +85,14 @@ private slots:
     void onGlobalActionTriggered(const QString &actionName);
 
 private:
+    enum class StatusMode {
+        Idle,
+        Loading,
+        Ready,
+        Empty,
+        Error,
+    };
+
     bool eventFilter(QObject *watched, QEvent *event) override;
     void showInstructionHelpAt(const QPoint &pos, bool forceByCursor = false);
 
@@ -142,6 +150,8 @@ private:
 
     int m_currentSectionIndex = -1;
     QTimer *m_refreshDebounce = nullptr;
+    StatusMode m_statusMode = StatusMode::Idle;
+    QString m_statusDetail;
 };
 
 #endif // DISASSEMBLERTAB_H

--- a/src/ToolTabs/other/Disassembler/disassemblertab.h
+++ b/src/ToolTabs/other/Disassembler/disassemblertab.h
@@ -99,6 +99,9 @@ private:
     void rebuildFunctionsFromLines();          // objdump labels
     void setFunctionsList(const QVector<DisasmFunction> &funcs);
     void jumpToAddress(const QString &addr);
+    const LineInfo *currentLineInfo(int *visibleLine = nullptr) const;
+    int currentInstructionOrdinal(int visibleLine) const;
+    void updateStatusState();
     QString autoCommentForLine(const LineInfo &li) const;
     bool tryResolveStringRefAddr(const LineInfo &li, quint64 *outAddr) const;
 

--- a/src/app/IDEWindow/idewindow.cpp
+++ b/src/app/IDEWindow/idewindow.cpp
@@ -3,6 +3,7 @@
 #include "widgets/filetab.h"
 #include "QFileSystemModel"
 #include "QMessageBox"
+#include <QLabel>
 #include <qheaderview.h>
 #include <qjsondocument.h>
 #include <qjsonobject.h>
@@ -10,6 +11,15 @@
 #include "dialogs/settingsdialog.h"
 #include "ui/MenuBar/menubarbuilder.h"
 #include "widgets/CustomCodeEditor.h"
+
+namespace {
+
+QString normalizedStatusText(const QString& text)
+{
+    return text.isEmpty() ? QStringLiteral(" ") : text;
+}
+
+}
 
 IDEWindow::IDEWindow(QString ProjectPath, QWidget *parent)
     : QMainWindow(parent), m_projectPath(ProjectPath)
@@ -25,6 +35,7 @@ IDEWindow::IDEWindow(QString ProjectPath, QWidget *parent)
 
     // - - Widgets - -
     m_statusBar = statusBar();
+    setupStatusBar();
 
     m_mainWidget = new QWidget(this);
     m_mainLayout = new QHBoxLayout(m_mainWidget);
@@ -109,6 +120,9 @@ IDEWindow::IDEWindow(QString ProjectPath, QWidget *parent)
     connect(m_filesTabWidget, &QTabWidget::tabCloseRequested,m_filesTabWidget, &FilesTabWidget::closeTab);
     connect(m_filesTreeView, &QTreeView::customContextMenuRequested,this, &IDEWindow::on_Tree_ContextMenu);
     connect(m_filesTreeView, &QTreeView::doubleClicked, this, &IDEWindow::on_treeView_doubleClicked);
+    connect(m_filesTabWidget, &FilesTabWidget::activeStatusStateChanged, this, &IDEWindow::onActiveStatusStateChanged);
+
+    applyStatusState(m_filesTabWidget->currentStatusState());
 }
 
 IDEWindow::~IDEWindow()
@@ -117,6 +131,35 @@ IDEWindow::~IDEWindow()
 FileTab* IDEWindow::currentFileTab() const
 {
     return qobject_cast<FileTab*>(m_filesTabWidget->currentWidget());
+}
+
+void IDEWindow::setupStatusBar()
+{
+    m_statusLeftLabel = new QLabel(this);
+    m_statusCenterLabel = new QLabel(this);
+    m_statusRightLabel = new QLabel(this);
+
+    m_statusLeftLabel->setMinimumWidth(160);
+    m_statusCenterLabel->setMinimumWidth(160);
+    m_statusRightLabel->setMinimumWidth(160);
+
+    m_statusBar->addPermanentWidget(m_statusLeftLabel, 1);
+    m_statusBar->addPermanentWidget(m_statusCenterLabel, 1);
+    m_statusBar->addPermanentWidget(m_statusRightLabel, 1);
+
+    applyStatusState({"No file open", "", ""});
+}
+
+void IDEWindow::applyStatusState(const ToolStatusState& state)
+{
+    m_statusLeftLabel->setText(normalizedStatusText(state.left));
+    m_statusCenterLabel->setText(normalizedStatusText(state.center));
+    m_statusRightLabel->setText(normalizedStatusText(state.right));
+}
+
+void IDEWindow::onActiveStatusStateChanged(const ToolStatusState& state)
+{
+    applyStatusState(state);
 }
 
 bool IDEWindow::openToolForCurrentFile(const QString& toolId)

--- a/src/app/IDEWindow/idewindow.cpp
+++ b/src/app/IDEWindow/idewindow.cpp
@@ -11,6 +11,7 @@
 #include "dialogs/settingsdialog.h"
 #include "ui/MenuBar/menubarbuilder.h"
 #include "widgets/CustomCodeEditor.h"
+#include <QHBoxLayout>
 
 namespace {
 
@@ -139,13 +140,27 @@ void IDEWindow::setupStatusBar()
     m_statusCenterLabel = new QLabel(this);
     m_statusRightLabel = new QLabel(this);
 
-    m_statusLeftLabel->setMinimumWidth(160);
-    m_statusCenterLabel->setMinimumWidth(160);
-    m_statusRightLabel->setMinimumWidth(160);
+    m_statusLeftLabel->setAlignment(Qt::AlignVCenter | Qt::AlignLeft);
+    m_statusCenterLabel->setAlignment(Qt::AlignVCenter | Qt::AlignLeft);
+    m_statusRightLabel->setAlignment(Qt::AlignVCenter | Qt::AlignLeft);
+    m_statusLeftLabel->setMinimumWidth(78);
+    m_statusCenterLabel->setMinimumWidth(92);
+    m_statusRightLabel->setMinimumWidth(96);
 
-    m_statusBar->addPermanentWidget(m_statusLeftLabel, 1);
-    m_statusBar->addPermanentWidget(m_statusCenterLabel, 1);
-    m_statusBar->addPermanentWidget(m_statusRightLabel, 1);
+    auto* spacer = new QWidget(m_statusBar);
+    spacer->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Preferred);
+
+    auto* statusGroup = new QWidget(m_statusBar);
+    auto* statusLayout = new QHBoxLayout(statusGroup);
+    statusLayout->setContentsMargins(0, 0, 10, 0);
+    statusLayout->setSpacing(32);
+    statusLayout->addWidget(m_statusLeftLabel);
+    statusLayout->addWidget(m_statusCenterLabel);
+    statusLayout->addWidget(m_statusRightLabel);
+
+    m_statusBar->setSizeGripEnabled(false);
+    m_statusBar->addWidget(spacer, 1);
+    m_statusBar->addPermanentWidget(statusGroup);
 
     applyStatusState({"No file open", "", ""});
 }

--- a/src/app/IDEWindow/idewindow.h
+++ b/src/app/IDEWindow/idewindow.h
@@ -1,6 +1,7 @@
 #ifndef IDEWINDOW_H
 #define IDEWINDOW_H
 
+#include "core/ToolStatusState.h"
 #include "filestabwidget.h"
 #include "filetreeview.h"
 #include <QMainWindow>
@@ -9,6 +10,8 @@
 #include <qsplitter.h>
 #include <qstatusbar.h>
 #include "widgets/terminal/terminalwidget.h"
+
+class QLabel;
 
 class IDEWindow : public QMainWindow
 {
@@ -35,9 +38,13 @@ private slots:
     */
     void on_Tree_ContextMenu(const QPoint &pos);
 
+    void onActiveStatusStateChanged(const ToolStatusState& state);
+
 
 private:
     FileTab* currentFileTab() const;
+    void setupStatusBar();
+    void applyStatusState(const ToolStatusState& state);
 
     // - - Main Widgets - -
     QMenuBar* m_menuBar;
@@ -57,6 +64,9 @@ private:
     // - - Terminal Widget - -
     TerminalWidget* m_terminal;
     QString m_projectPath;
+    QLabel* m_statusLeftLabel = nullptr;
+    QLabel* m_statusCenterLabel = nullptr;
+    QLabel* m_statusRightLabel = nullptr;
 
 
 public slots:

--- a/src/core/ToolStatusState.h
+++ b/src/core/ToolStatusState.h
@@ -1,0 +1,13 @@
+#ifndef TOOLSTATUSSTATE_H
+#define TOOLSTATUSSTATE_H
+
+#include <QString>
+
+struct ToolStatusState
+{
+    QString left;
+    QString center;
+    QString right;
+};
+
+#endif // TOOLSTATUSSTATE_H

--- a/src/core/ToolTab.h
+++ b/src/core/ToolTab.h
@@ -2,6 +2,7 @@
 #define TOOLTAB_H
 
 #include "FileDataBuffer.h"
+#include "ToolStatusState.h"
 #include "utils/filecontext.h"
 #include <QWidget>
 
@@ -27,6 +28,8 @@ protected:
      * Если true - данные изменены, false - данные равны данным в файле
      */
     bool m_modifyIndicator = false;
+
+    ToolStatusState m_statusState;
 
 public:
     /**
@@ -66,11 +69,27 @@ public:
         return m_modifyIndicator;
     }
 
+    ToolStatusState statusState() const {
+        return m_statusState;
+    }
+
     /**
      * @brief Установить значение индикатора изменений
      */
     void setModifyIndicator(bool value) {
         m_modifyIndicator = value;
+    }
+
+protected:
+    void setStatusState(const ToolStatusState& state) {
+        if (m_statusState.left == state.left &&
+            m_statusState.center == state.center &&
+            m_statusState.right == state.right) {
+            return;
+        }
+
+        m_statusState = state;
+        emit statusStateChanged(m_statusState);
     }
 
 protected slots:
@@ -108,6 +127,10 @@ protected slots:
     virtual void onDataChanged() {}
 
 public slots:
+    void publishStatusState() {
+        emit statusStateChanged(m_statusState);
+    }
+
     /**
      * @brief Установить файл инструменту
      *
@@ -148,6 +171,8 @@ signals:
      * Также эмиттится после вызова функции setTabData, чтобы убрать звезду
      */
     void dataEqual();
+
+    void statusStateChanged(const ToolStatusState& state);
 };
 
 #endif // TOOLTAB_H

--- a/src/core/ToolTab.h
+++ b/src/core/ToolTab.h
@@ -1,7 +1,7 @@
 #ifndef TOOLTAB_H
 #define TOOLTAB_H
 
-#include "FileDataBuffer.h"
+#include "core/FileDataBuffer.h"
 #include "ToolStatusState.h"
 #include "utils/filecontext.h"
 #include <QWidget>

--- a/src/libs/cremniy-codeeditor/include/widgets/CustomCodeEditor.h
+++ b/src/libs/cremniy-codeeditor/include/widgets/CustomCodeEditor.h
@@ -58,6 +58,8 @@ public:
     // State queries
     bool isModified() const;
     qint64 cursorPosition() const;
+    qint64 cursorLineNumber() const;
+    qint64 cursorColumnNumber() const;
     qint64 lineCount() const;
     bool hasSelection() const;
     QString selectedText() const;

--- a/src/libs/cremniy-codeeditor/src/widgets/CustomCodeEditor.cpp
+++ b/src/libs/cremniy-codeeditor/src/widgets/CustomCodeEditor.cpp
@@ -921,6 +921,22 @@ qint64 CustomCodeEditor::cursorPosition() const
     return m_cursorBytePos;
 }
 
+qint64 CustomCodeEditor::cursorLineNumber() const
+{
+    if (!m_buffer)
+        return 1;
+
+    return lineFromBytePos(m_cursorBytePos) + 1;
+}
+
+qint64 CustomCodeEditor::cursorColumnNumber() const
+{
+    if (!m_buffer)
+        return 1;
+
+    return columnForBytePos(lineFromBytePos(m_cursorBytePos), m_cursorBytePos) + 1;
+}
+
 qint64 CustomCodeEditor::lineCount() const
 {
     return m_lineIndex->lineCount();

--- a/src/ui/filestabwidget.cpp
+++ b/src/ui/filestabwidget.cpp
@@ -23,8 +23,21 @@ FilesTabWidget::FilesTabWidget(QWidget *parent) {
 
 void FilesTabWidget::tabSelect(int index) {
     FileTab *tab = qobject_cast<FileTab *>(widget(index));
-    if (!tab)
+    if (!tab) {
+        emit activeStatusStateChanged({"No file open", "", ""});
         return;
+    }
+    
+    emit activeStatusStateChanged(tab->currentStatusState());
+}
+
+ToolStatusState FilesTabWidget::currentStatusState() const
+{
+    FileTab* tab = qobject_cast<FileTab*>(currentWidget());
+    if (!tab)
+        return {"No file open", "", ""};
+
+    return tab->currentStatusState();
 }
 
 // Create new tab and open file if he is not open already
@@ -48,6 +61,7 @@ void FilesTabWidget::openFile(QString filePath, QString tabTitle) {
     connect(filetab, &FileTab::removeStarSignal, this, &FilesTabWidget::removeStar);
     connect(filetab, &FileTab::setupStarSignal, this, &FilesTabWidget::setupStar);
     connect(filetab, &FileTab::pinnedChanged, this, &FilesTabWidget::updatePinnedState);
+    connect(filetab, &FileTab::activeStatusStateChanged, this, &FilesTabWidget::onFileTabActiveStatusStateChanged);
 }
 
 void FilesTabWidget::removeStar(FileTab *tab) {
@@ -192,6 +206,8 @@ void FilesTabWidget::closeTab(int index) {
     removeTab(index);
     if (tab)
         tab->deleteLater();
+
+    emit activeStatusStateChanged(currentStatusState());
 }
 
 void FilesTabWidget::switchTab(int page) {
@@ -274,4 +290,12 @@ int FilesTabWidget::pinnedCount() const {
         }
     }
     return countPinned;
+}
+
+void FilesTabWidget::onFileTabActiveStatusStateChanged(const ToolStatusState& state)
+{
+    if (sender() != currentWidget())
+        return;
+
+    emit activeStatusStateChanged(state);
 }

--- a/src/ui/filestabwidget.h
+++ b/src/ui/filestabwidget.h
@@ -1,6 +1,7 @@
 #ifndef FILESTABWIDGET_H
 #define FILESTABWIDGET_H
 
+#include "core/ToolStatusState.h"
 #include <QTabWidget>
 #include <filetab.h>
 
@@ -9,6 +10,7 @@ class FilesTabWidget : public QTabWidget {
 public:
   FilesTabWidget(QWidget *parent = nullptr);
 
+  ToolStatusState currentStatusState() const;
   void tabSelect(int index);
   void openFile(QString fullPath, QString fileName);
 
@@ -24,10 +26,14 @@ public slots:
   void onTabMoved(int from, int to);
   
 private:
+  void onFileTabActiveStatusStateChanged(const ToolStatusState &state);
   void switchTab(int page);
   void setPinnedTabText(int index, FileTab *tab);
   int pinnedCount() const;
   bool m_adjustingTabMove = false;
+
+signals:
+  void activeStatusStateChanged(const ToolStatusState &state);
 };
 
 #endif // FILESTABWIDGET_H

--- a/src/ui/toolstabwidget.cpp
+++ b/src/ui/toolstabwidget.cpp
@@ -39,27 +39,40 @@ ToolsTabWidget::ToolsTabWidget(QWidget *parent, QString path)
     }
 
     connect(this, &QTabWidget::currentChanged, this, [this](int index) {
-        if (index < 0)
+        if (index < 0) {
+            setActiveToolTab(nullptr);
             return;
+        }
 
         ToolTab* tab = dynamic_cast<ToolTab*>(this->widget(index));
-        if (!tab)
+        if (!tab) {
+            setActiveToolTab(nullptr);
             return;
+        }
 
         if (!tab->property("tabDataLoaded").toBool()) {
             qDebug() << "ToolsTabWidget currentChanged: loading tab index=" << index << " ptr=" << tab << " name=" << tab->toolName();
             tab->setTabData();
             tab->setProperty("tabDataLoaded", true);
         }
+
+        setActiveToolTab(tab);
     });
 
     connect(this, &QTabWidget::tabCloseRequested, this, &ToolsTabWidget::closeToolTab);
+
+    setActiveToolTab(qobject_cast<ToolTab*>(currentWidget()));
 
     // // - - Connects - -
 
     // // Trigger: Menu Bar: File->SaveFile or CTRL+S - saveTabData
     // connect(GlobalWidgetsManager::instance().get_IDEWindow_menuBar_file_saveFile(),
             // &QAction::triggered, this, &ToolsTabWidget::saveCurrentTabData);
+}
+
+ToolStatusState ToolsTabWidget::currentStatusState() const
+{
+    return m_activeStatusState;
 }
 
 void ToolsTabWidget::updateCloseButtons()
@@ -128,6 +141,30 @@ ToolTab* ToolsTabWidget::createToolTab(const QString& toolId)
     return tab;
 }
 
+void ToolsTabWidget::setActiveToolTab(ToolTab* tab)
+{
+    if (m_activeToolTab) {
+        disconnect(m_activeToolTab, &ToolTab::statusStateChanged, this, nullptr);
+    }
+
+    m_activeToolTab = tab;
+
+    if (!m_activeToolTab) {
+        m_activeStatusState = {"No tool selected", "", ""};
+        emit activeStatusStateChanged(m_activeStatusState);
+        return;
+    }
+
+    connect(m_activeToolTab, &ToolTab::statusStateChanged, this, [this](const ToolStatusState& state) {
+        m_activeStatusState = state;
+        emit activeStatusStateChanged(m_activeStatusState);
+    });
+
+    m_activeStatusState = m_activeToolTab->statusState();
+    emit activeStatusStateChanged(m_activeStatusState);
+    m_activeToolTab->publishStatusState();
+}
+
 ToolTab* ToolsTabWidget::openToolTab(const QString& toolId, bool activate)
 {
     ToolTab* tab = findToolTab(toolId);
@@ -170,6 +207,10 @@ void ToolsTabWidget::closeToolTab(int index)
     removeTab(index);
     toolWidget->deleteLater();
     updateCloseButtons();
+
+    if (currentIndex() < 0) {
+        setActiveToolTab(nullptr);
+    }
 }
 
 void ToolsTabWidget::saveCurrentTabData(){

--- a/src/ui/toolstabwidget.cpp
+++ b/src/ui/toolstabwidget.cpp
@@ -143,26 +143,36 @@ ToolTab* ToolsTabWidget::createToolTab(const QString& toolId)
 
 void ToolsTabWidget::setActiveToolTab(ToolTab* tab)
 {
-    if (m_activeToolTab) {
-        disconnect(m_activeToolTab, &ToolTab::statusStateChanged, this, nullptr);
-    }
+    if (m_activeStatusConnection)
+        disconnect(m_activeStatusConnection);
 
     m_activeToolTab = tab;
 
     if (!m_activeToolTab) {
-        m_activeStatusState = {"No tool selected", "", ""};
-        emit activeStatusStateChanged(m_activeStatusState);
+        updateActiveStatusState({"No tool selected", "", ""});
         return;
     }
 
-    connect(m_activeToolTab, &ToolTab::statusStateChanged, this, [this](const ToolStatusState& state) {
-        m_activeStatusState = state;
-        emit activeStatusStateChanged(m_activeStatusState);
-    });
+    m_activeStatusConnection = connect(
+        m_activeToolTab,
+        &ToolTab::statusStateChanged,
+        this,
+        &ToolsTabWidget::updateActiveStatusState
+    );
 
-    m_activeStatusState = m_activeToolTab->statusState();
+    updateActiveStatusState(m_activeToolTab->statusState());
+}
+
+void ToolsTabWidget::updateActiveStatusState(const ToolStatusState& state)
+{
+    if (m_activeStatusState.left == state.left &&
+        m_activeStatusState.center == state.center &&
+        m_activeStatusState.right == state.right) {
+        return;
+    }
+
+    m_activeStatusState = state;
     emit activeStatusStateChanged(m_activeStatusState);
-    m_activeToolTab->publishStatusState();
 }
 
 ToolTab* ToolsTabWidget::openToolTab(const QString& toolId, bool activate)

--- a/src/ui/toolstabwidget.h
+++ b/src/ui/toolstabwidget.h
@@ -1,6 +1,7 @@
 #ifndef TOOLTABWIDGET_H
 #define TOOLTABWIDGET_H
 
+#include "core/ToolStatusState.h"
 #include <QByteArray>
 #include <QString>
 #include <QTabWidget>
@@ -21,6 +22,7 @@ class ToolsTabWidget : public QTabWidget
     Q_OBJECT
 public:
     ToolsTabWidget(QWidget *parent, QString path);
+    ToolStatusState currentStatusState() const;
     ToolTab* openToolTab(const QString& toolId, bool activate = true);
     int saveToFileCurrentTab(QString path);
     void setDataInTabs(QByteArray &data, int index = -1, int excluded_index = -1);
@@ -29,9 +31,12 @@ private:
     void loadStyle(QString path, QString name);
     ToolTab* findToolTab(const QString& toolId) const;
     ToolTab* createToolTab(const QString& toolId);
+    void setActiveToolTab(ToolTab* tab);
     void updateCloseButtons();
     FileDataBuffer* m_sharedBuffer = nullptr;
     QString m_filePath;
+    ToolTab* m_activeToolTab = nullptr;
+    ToolStatusState m_activeStatusState = {"No tool selected", "", ""};
 
 public slots:
     void closeToolTab(int index);
@@ -45,6 +50,7 @@ signals:
     void removeStarSignal();
     void setupStarSignal();
     void saveFileSignal();
+    void activeStatusStateChanged(const ToolStatusState& state);
 
 };
 

--- a/src/ui/toolstabwidget.h
+++ b/src/ui/toolstabwidget.h
@@ -5,6 +5,7 @@
 #include <QByteArray>
 #include <QString>
 #include <QTabWidget>
+#include <QMetaObject>
 
 class QVBoxLayout;
 class QSyntaxStyle;
@@ -33,10 +34,12 @@ private:
     ToolTab* createToolTab(const QString& toolId);
     void setActiveToolTab(ToolTab* tab);
     void updateCloseButtons();
+    void updateActiveStatusState(const ToolStatusState& state);
     FileDataBuffer* m_sharedBuffer = nullptr;
     QString m_filePath;
     ToolTab* m_activeToolTab = nullptr;
     ToolStatusState m_activeStatusState = {"No tool selected", "", ""};
+    QMetaObject::Connection m_activeStatusConnection;
 
 public slots:
     void closeToolTab(int index);

--- a/src/widgets/filetab.cpp
+++ b/src/widgets/filetab.cpp
@@ -17,9 +17,15 @@ FileTab::FileTab(QWidget* parent, QString path)
     // - - Connects - -
     connect(m_tooltabWidget, &ToolsTabWidget::removeStarSignal, this, &FileTab::removeStar);
     connect(m_tooltabWidget, &ToolsTabWidget::setupStarSignal, this, &FileTab::setupStar);
+    connect(m_tooltabWidget, &ToolsTabWidget::activeStatusStateChanged, this, &FileTab::activeStatusStateChanged);
 
     connect(this, &FileTab::saveFileSignal, m_tooltabWidget, &ToolsTabWidget::saveCurrentTabData);
 
+}
+
+ToolStatusState FileTab::currentStatusState() const
+{
+    return m_tooltabWidget->currentStatusState();
 }
 
 void FileTab::setPinned(bool pinned){

--- a/src/widgets/filetab.h
+++ b/src/widgets/filetab.h
@@ -1,6 +1,7 @@
 #ifndef FILETAB_H
 #define FILETAB_H
 
+#include "core/ToolStatusState.h"
 #include "toolstabwidget.h"
 #include <QWidget>
 
@@ -16,6 +17,7 @@ private:
 public:
     explicit FileTab(QWidget *parrent, QString path);
     QString filePath;
+    ToolStatusState currentStatusState() const;
     bool isFileUnsaved() const { return m_modified; }
     bool isPinned() const { return m_pinned; }
     void setPinned(bool pinned);
@@ -31,6 +33,7 @@ signals:
     void setupStarSignal(FileTab* tab);
     void saveFileSignal();
     void pinnedChanged(FileTab* tab);
+    void activeStatusStateChanged(const ToolStatusState& state);
 
 };
 


### PR DESCRIPTION
## Summary

This PR adds a bottom status bar to the main IDE window with context-specific information for the currently active tool.

Currently supported:
- Code editor: line, column, file language
- Binary RAW: byte address, byte index
- Disassembler: instruction address, instruction index

Also added a top separator to visually distinguish the status bar from the workspace.

## Implementation

The feature is implemented with a shared `ToolStatusState` model.

After review, the internal status propagation was refactored to keep module boundaries clean:
- `BinaryTab` no longer depends on `RAWPage` directly.
- Binary format pages expose status bar data through a shared `FormatPage` status API.
- Only `ToolsTabWidget` knows about `ToolTab`.
- `FileTab`, `FilesTabWidget`, and `IDEWindow` now work only with `ToolStatusState`.

`IDEWindow` now consumes status bar state through a clean API when switching file tabs and tool tabs, without working directly with `ToolTab`.

## Tested

- text file: line / column / language updates
- binary RAW: byte address / byte index updates
- disassembler: instruction address / instruction index updates
- switching between file tabs and tool tabs without stale status
- fallback state when no file is open
- top separator rendering above the status bar

## Screenshot

<img width="1912" height="1043" alt="image" src="https://github.com/user-attachments/assets/5804aefb-9e7e-4369-9cf6-cc9fd0773432" />