### PR TITLE
Fix code editor linkage in CMake

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -90,6 +90,7 @@ qt_add_executable(${PROJECT_NAME}
 
 target_include_directories(${PROJECT_NAME} PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/libs/cremniy-codeeditor/include
+    ${CMAKE_CURRENT_SOURCE_DIR}/libs/cremniy-codeeditor/third_party/QCodeEditor/include
     ${CMAKE_CURRENT_SOURCE_DIR}
     ${CMAKE_CURRENT_SOURCE_DIR}/widgets
     ${CMAKE_CURRENT_SOURCE_DIR}/include
@@ -105,7 +106,10 @@ add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/libs/cremniy-codeeditor ${CMAKE_BIN
 add_subdirectory(ToolTabs/always)
 add_subdirectory(ToolTabs/other)
 
-target_link_libraries(${PROJECT_NAME} PRIVATE Qt6::Widgets)
+target_link_libraries(${PROJECT_NAME} PRIVATE
+    Qt6::Widgets
+    cremniy-codeeditor
+)
 
 find_program(WINDEPLOYQT_EXECUTABLE windeployqt)
 


### PR DESCRIPTION
## Summary
- add the vendored QCodeEditor include path to the main app target
- link the main executable with the cremniy-codeeditor library

## Why
The app target uses FileDataBuffer and CustomCodeEditor symbols provided by the shared editor library, but the main CMake target was not linked against that library and was also missing the vendored QCodeEditor include path. This keeps the build wiring self-consistent on dev.