### PR TITLE
Fix HexView on MacOS

### DIFF
--- a/src/ToolTabs/Binary/QHexView/src/qhexview.cpp
+++ b/src/ToolTabs/Binary/QHexView/src/qhexview.cpp
@@ -129,11 +129,7 @@ void QHexView::PaintContext::advanceX() { x += this->hexview->cellWidth(); }
 QHexView::QHexView(QWidget* parent)
     : QAbstractScrollArea(parent), m_fontmetrics(this->font()) {
     QFont f = QFontDatabase::systemFont(QFontDatabase::FixedFont);
-
-    if(f.styleHint() != QFont::TypeWriter) {
-        f.setFamily("Monospace"); // Force Monospaced font
-        f.setStyleHint(QFont::TypeWriter);
-    }
+    f.setStyleHint(QFont::Monospace);
 
     this->setFont(f);
     this->setMouseTracking(true);


### PR DESCRIPTION
Fixes #43 

Why current HexView does fail on MacOS:
- `QFont::TypeWriter` binds **only to one font** `Courier` (check "Value" in [docs](https://doc.qt.io/qt-6/qfont.html#StyleHint-enum)).
- MacOS essentially deprecated this font and hides it:
  - `Courier` is not present in "Font book" application <img width="550" height="249" alt="image" src="https://github.com/user-attachments/assets/22a070c0-e6f5-48a2-9869-98cc57353e2f" />
  - In official Apple's [list of fonts](https://support.apple.com/en-us/122869) only font `Courier New` present in "Installed or downloadable fonts",
whilst `Courier` is in "deprecated" list ("These fonts are available only to documents **that already use the font**, or to apps that request the font by name")

Since constraint to only one font is a harsh limit (which breaks core functionality if not satisfied),
I find it essential to replace it with more broad, but more functionally correct option of `QFont::Monospace`

---

Luckily, this change preserves HexView behaviour on other OS:
- Ubuntu (22.04)
- Windows (11)
I tested view, editing and fonts — even font stays the same 
(checked using `qDebug() << f.family() << f.style() << f.styleName();`)

Meanwhile on MacOS this changes font 
from `"Monospace" QFont::StyleNormal ""` 
to `"Menlo" QFont::StyleNormal ""`
bringing the correct presentation of HexView
<img width="1103" height="895" alt="image" src="https://github.com/user-attachments/assets/08d51fa8-2455-42f6-b368-2f0a88c51798" />
