### PR TITLE
feat: Implement StatusBar (#73)

### DIFF
--- a/src/Tools/Tabs/Binary/FormatPages/RAW/rawpage.cpp
+++ b/src/Tools/Tabs/Binary/FormatPages/RAW/rawpage.cpp
@@ -60,6 +60,12 @@ RAWPage::RAWPage(QWidget *parent)
                     // A single click in hex view focuses 1 byte visually. It should transfer as a 1 byte selection to Code Editor.
                     emit selectionChanged(m_hexViewWidget->hexCursor()->offset(), 1);
                 }
+
+                qint64 offset = m_hexViewWidget->hexCursor()->offset();
+                emit statusBarInfoChanged(
+                    QString("Addr: 0x%1    Byte: %2")
+                        .arg(offset, 0, 16)
+                        .arg(offset));
             });
 
 }

--- a/src/Tools/Tabs/Binary/binarytab.cpp
+++ b/src/Tools/Tabs/Binary/binarytab.cpp
@@ -79,8 +79,12 @@ BinaryTab::BinaryTab(FileDataBuffer* buffer, QWidget *parent)
                         }
                     });
             
+            // Forward status bar info from format page
+            connect(fpage, &FormatPage::statusBarInfoChanged,
+                    this, &BinaryTab::statusBarInfoChanged);
+
             // Подключаем сигнал выделения от страницы к буферу
-            connect(fpage, &FormatPage::selectionChanged, 
+            connect(fpage, &FormatPage::selectionChanged,
                     this, [this](qint64 pos, qint64 length){
                         if (m_updatingSelection) return; // Предотвращаем рекурсию
                         

--- a/src/Tools/Tabs/Binary/formatpage.h
+++ b/src/Tools/Tabs/Binary/formatpage.h
@@ -33,6 +33,7 @@ signals:
     void dataEqual();
     void selectionChanged(qint64 pos, qint64 length);
     void pageDataChanged(const QByteArray& data);
+    void statusBarInfoChanged(const QString& info);
 
 
 };

--- a/src/Tools/Tabs/CodeEditor/codeeditortab.cpp
+++ b/src/Tools/Tabs/CodeEditor/codeeditortab.cpp
@@ -107,6 +107,14 @@ CodeEditorTab::CodeEditorTab(FileDataBuffer* buffer, QWidget* parent)
         updateSearchUi();
     });
 
+    connect(m_codeEditorWidget, &CustomCodeEditor::cursorPositionChanged, this, [this]() {
+        emit statusBarInfoChanged(
+            QString("Ln %1, Col %2    %3")
+                .arg(m_codeEditorWidget->cursorLine())
+                .arg(m_codeEditorWidget->cursorColumn())
+                .arg(m_currentLang));
+    });
+
     connect(m_codeEditorWidget, &CustomCodeEditor::contentsChanged, this, [this]() {
         if (m_dataBuffer->isModified()) {
             setModifyIndicator(true);
@@ -246,6 +254,45 @@ void CodeEditorTab::setFile(QString filepath)
 {
     m_fileContext = new FileContext(filepath);
     m_codeEditorWidget->setFileExt(CustomCodeEditor::syntaxKeyForPath(filepath));
+    m_currentLang = detectLanguage(filepath);
+}
+
+QString CodeEditorTab::detectLanguage(const QString& filePath)
+{
+    QFileInfo fi(filePath);
+    QString ext = fi.suffix().toLower();
+    QString baseName = fi.fileName().toLower();
+
+    static const QHash<QString, QString> extMap = {
+        {"c", "C"}, {"h", "C"},
+        {"cpp", "C++"}, {"cxx", "C++"}, {"cc", "C++"}, {"hpp", "C++"}, {"hxx", "C++"},
+        {"py", "Python"},
+        {"rs", "Rust"},
+        {"asm", "Assembly"}, {"s", "Assembly"},
+        {"js", "JavaScript"},
+        {"ts", "TypeScript"},
+        {"java", "Java"},
+        {"go", "Go"},
+        {"cmake", "CMake"},
+        {"mk", "Makefile"}, {"make", "Makefile"},
+        {"sh", "Shell"}, {"bash", "Shell"}, {"zsh", "Shell"},
+        {"json", "JSON"}, {"xml", "XML"}, {"html", "HTML"}, {"css", "CSS"},
+    };
+
+    if (extMap.contains(ext))
+        return extMap.value(ext);
+
+    if (ext.isEmpty()) {
+        if (baseName == "makefile" || baseName == "gnumakefile")
+            return "Makefile";
+        if (baseName == "cmakelists.txt")
+            return "CMake";
+        if (baseName == "dockerfile")
+            return "Dockerfile";
+        return "Plain Text";
+    }
+
+    return ext.toUpper();
 }
 
 void CodeEditorTab::setTabData()

--- a/src/Tools/Tabs/CodeEditor/codeeditortab.h
+++ b/src/Tools/Tabs/CodeEditor/codeeditortab.h
@@ -51,7 +51,9 @@ private:
     QShortcut* m_goToLineShortcut = nullptr;
     QShortcut* m_replaceShortcut = nullptr;
     bool m_replaceMode = false;
+    QString m_currentLang = "Plain Text";
 
+    static QString detectLanguage(const QString& filePath);
     void openFindDialog();
     void openReplaceDialog();
     void findNext(bool forward = true);

--- a/src/Tools/Tabs/Disassembler/disassemblertab.cpp
+++ b/src/Tools/Tabs/Disassembler/disassemblertab.cpp
@@ -482,10 +482,28 @@ void DisassemblerTab::setupUi()
     m_disasmView->viewport()->installEventFilter(this);
     m_disasmHighlighter = new DisasmTextHighlighter(m_disasmView->document());
     connect(m_disasmView, &QPlainTextEdit::cursorPositionChanged, this, [this]() {
-        if (!m_disasmView || !m_disasmView->hasFocus())
-            return;
-        const QPoint p = m_disasmView->cursorRect().bottomRight();
-        showInstructionHelpAt(p, true);
+        if (!m_disasmView) return;
+
+        // Instruction help tooltip (only when focused)
+        if (m_disasmView->hasFocus()) {
+            const QPoint p = m_disasmView->cursorRect().bottomRight();
+            showInstructionHelpAt(p, true);
+        }
+
+        // Status bar update
+        int visLine = m_disasmView->textCursor().blockNumber();
+        if (visLine < 0 || visLine >= m_visibleLineMap.size()) return;
+
+        int idx = m_visibleLineMap[visLine];
+        if (idx < 0 || idx >= m_lines.size()) return;
+
+        const LineInfo& li = m_lines[idx];
+        if (li.address.isEmpty()) return;
+
+        emit statusBarInfoChanged(
+            QString("Addr: %1    Instr: #%2")
+                .arg(li.address.trimmed())
+                .arg(visLine + 1));
     });
 
     // Обработчик выделения в дизассемблере - уведомляем буфер

--- a/src/app/IDEWindow/idewindow.cpp
+++ b/src/app/IDEWindow/idewindow.cpp
@@ -25,6 +25,8 @@ IDEWindow::IDEWindow(QString ProjectPath, QWidget *parent)
 
     // - - Widgets - -
     m_statusBar = statusBar();
+    m_statusLabel = new QLabel(this);
+    m_statusBar->addPermanentWidget(m_statusLabel);
 
     m_mainWidget = new QWidget(this);
     m_mainLayout = new QHBoxLayout(m_mainWidget);
@@ -109,7 +111,7 @@ IDEWindow::IDEWindow(QString ProjectPath, QWidget *parent)
 
     connect(m_filesTabWidget, &FilesTabWidget::statusBarInfoChanged,
             this, [this](const QString& info) {
-                m_statusBar->showMessage(info);
+                m_statusLabel->setText(info);
             });
 
     connect(m_filesTabWidget, &QTabWidget::tabCloseRequested,m_filesTabWidget, &FilesTabWidget::closeTab);

--- a/src/app/IDEWindow/idewindow.cpp
+++ b/src/app/IDEWindow/idewindow.cpp
@@ -107,6 +107,11 @@ IDEWindow::IDEWindow(QString ProjectPath, QWidget *parent)
 
     connect(this, &IDEWindow::saveFileSignal, m_filesTabWidget, &FilesTabWidget::saveFileSlot);
 
+    connect(m_filesTabWidget, &FilesTabWidget::statusBarInfoChanged,
+            this, [this](const QString& info) {
+                m_statusBar->showMessage(info);
+            });
+
     connect(m_filesTabWidget, &QTabWidget::tabCloseRequested,m_filesTabWidget, &FilesTabWidget::closeTab);
     connect(m_filesTreeView, &QTreeView::customContextMenuRequested,this, &IDEWindow::on_Tree_ContextMenu);
     connect(m_filesTreeView, &QTreeView::doubleClicked, this, &IDEWindow::on_treeView_doubleClicked);

--- a/src/app/IDEWindow/idewindow.h
+++ b/src/app/IDEWindow/idewindow.h
@@ -8,6 +8,7 @@
 #include <qmenubar.h>
 #include <qsplitter.h>
 #include <qstatusbar.h>
+#include <QLabel>
 #include "widgets/terminal/terminalwidget.h"
 
 class IDEWindow : public QMainWindow
@@ -42,6 +43,7 @@ private:
     // - - Main Widgets - -
     QMenuBar* m_menuBar;
     QStatusBar* m_statusBar;
+    QLabel* m_statusLabel;
     QWidget* m_mainWidget;
     QHBoxLayout* m_mainLayout;
     QSplitter* m_verticalSplitter;  // splitter (вверх вниз)

--- a/src/libs/CodeEditor/include/widgets/CustomCodeEditor.h
+++ b/src/libs/CodeEditor/include/widgets/CustomCodeEditor.h
@@ -59,6 +59,8 @@ public:
     // State queries
     bool isModified() const;
     qint64 cursorPosition() const;
+    qint64 cursorLine() const;
+    qint64 cursorColumn() const;
     qint64 lineCount() const;
     bool hasSelection() const;
     QString selectedText() const;

--- a/src/libs/CodeEditor/src/widgets/CustomCodeEditor.cpp
+++ b/src/libs/CodeEditor/src/widgets/CustomCodeEditor.cpp
@@ -921,6 +921,17 @@ qint64 CustomCodeEditor::cursorPosition() const
     return m_cursorBytePos;
 }
 
+qint64 CustomCodeEditor::cursorLine() const
+{
+    return lineFromBytePos(m_cursorBytePos) + 1;
+}
+
+qint64 CustomCodeEditor::cursorColumn() const
+{
+    qint64 line = lineFromBytePos(m_cursorBytePos);
+    return columnForBytePos(line, m_cursorBytePos) + 1;
+}
+
 qint64 CustomCodeEditor::lineCount() const
 {
     return m_lineIndex->lineCount();

--- a/src/ui/FilesTabWidget/filestabwidget.cpp
+++ b/src/ui/FilesTabWidget/filestabwidget.cpp
@@ -23,12 +23,13 @@ FilesTabWidget::FilesTabWidget(QWidget *parent) {
 
 void FilesTabWidget::tabSelect(int index) {
     FileTab *tab = qobject_cast<FileTab *>(widget(index));
-    if (!tab) {
+    if (!tab || !tab->toolsTabWidget()) {
         emit statusBarInfoChanged(QString());
         return;
     }
-    // Clear stale info; the active tool tab will emit fresh info on next cursor move
-    emit statusBarInfoChanged(QString());
+    QWidget* currentTool = tab->toolsTabWidget()->currentWidget();
+    QString lastInfo = currentTool ? currentTool->property("lastStatusBarInfo").toString() : QString();
+    emit statusBarInfoChanged(lastInfo);
 }
 
 // Create new tab and open file if he is not open already

--- a/src/ui/FilesTabWidget/filestabwidget.cpp
+++ b/src/ui/FilesTabWidget/filestabwidget.cpp
@@ -23,8 +23,12 @@ FilesTabWidget::FilesTabWidget(QWidget *parent) {
 
 void FilesTabWidget::tabSelect(int index) {
     FileTab *tab = qobject_cast<FileTab *>(widget(index));
-    if (!tab)
+    if (!tab) {
+        emit statusBarInfoChanged(QString());
         return;
+    }
+    // Clear stale info; the active tool tab will emit fresh info on next cursor move
+    emit statusBarInfoChanged(QString());
 }
 
 // Create new tab and open file if he is not open already
@@ -48,6 +52,7 @@ void FilesTabWidget::openFile(QString filePath, QString tabTitle) {
     connect(filetab, &FileTab::removeStarSignal, this, &FilesTabWidget::removeStar);
     connect(filetab, &FileTab::setupStarSignal, this, &FilesTabWidget::setupStar);
     connect(filetab, &FileTab::pinnedChanged, this, &FilesTabWidget::updatePinnedState);
+    connect(filetab, &FileTab::statusBarInfoChanged, this, &FilesTabWidget::statusBarInfoChanged);
 
     connect(this, &FilesTabWidget::setWordWrapSignal, filetab, &FileTab::setWordWrapSlot);
     connect(this, &FilesTabWidget::setTabReplaceSignal, filetab, &FileTab::setTabReplaceSlot);
@@ -197,6 +202,8 @@ void FilesTabWidget::closeTab(int index) {
     removeTab(index);
     if (tab)
         tab->deleteLater();
+    if (count() == 0)
+        emit statusBarInfoChanged(QString());
 }
 
 void FilesTabWidget::switchTab(int page) {

--- a/src/ui/FilesTabWidget/filestabwidget.h
+++ b/src/ui/FilesTabWidget/filestabwidget.h
@@ -37,6 +37,7 @@ signals:
     void setWordWrapSignal(bool checked);
     void setTabReplaceSignal(bool checked);
     void setTabWidthSignal(int width);
+    void statusBarInfoChanged(const QString& info);
 };
 
 #endif // FILESTABWIDGET_H

--- a/src/ui/ToolsTabWidget/ToolTab.h
+++ b/src/ui/ToolsTabWidget/ToolTab.h
@@ -142,6 +142,13 @@ public slots:
 
 signals:
     /**
+     * @brief Status bar information changed
+     *
+     * @param info text to display in the status bar
+     */
+    void statusBarInfoChanged(const QString& info);
+
+    /**
      * @brief Обновить данные из файла во всех вкладках
      *
      * Эмиттируется, когда нужно обновить данные на всех вкладках интерфейса

--- a/src/ui/ToolsTabWidget/toolstabwidget.cpp
+++ b/src/ui/ToolsTabWidget/toolstabwidget.cpp
@@ -51,6 +51,9 @@ ToolsTabWidget::ToolsTabWidget(QWidget *parent, QString path)
             tab->setTabData();
             tab->setProperty("tabDataLoaded", true);
         }
+
+        QString lastInfo = tab->property("lastStatusBarInfo").toString();
+        emit statusBarInfoChanged(lastInfo);
     });
 
     connect(this, &QTabWidget::tabCloseRequested, this, &ToolsTabWidget::closeToolTab);
@@ -110,6 +113,7 @@ ToolTab* ToolsTabWidget::createToolTab(const QString& toolId)
     connect(tab, &ToolTab::modifyData, this, &ToolsTabWidget::setupStar);
     connect(tab, &ToolTab::dataEqual, this, &ToolsTabWidget::removeStar);
     connect(tab, &ToolTab::statusBarInfoChanged, this, [this, tab](const QString& info) {
+        tab->setProperty("lastStatusBarInfo", info);
         if (currentWidget() == tab)
             emit statusBarInfoChanged(info);
     });

--- a/src/ui/ToolsTabWidget/toolstabwidget.cpp
+++ b/src/ui/ToolsTabWidget/toolstabwidget.cpp
@@ -109,6 +109,10 @@ ToolTab* ToolsTabWidget::createToolTab(const QString& toolId)
     connect(tab, &ToolTab::refreshDataAllTabsSignal, this, &ToolsTabWidget::refreshDataAllTabs);
     connect(tab, &ToolTab::modifyData, this, &ToolsTabWidget::setupStar);
     connect(tab, &ToolTab::dataEqual, this, &ToolsTabWidget::removeStar);
+    connect(tab, &ToolTab::statusBarInfoChanged, this, [this, tab](const QString& info) {
+        if (currentWidget() == tab)
+            emit statusBarInfoChanged(info);
+    });
 
     connect(this, &ToolsTabWidget::setWordWrapSignal, tab, &ToolTab::setWordWrapSlot);
     connect(this, &ToolsTabWidget::setTabReplaceSignal, tab, &ToolTab::setTabReplaceSlot);

--- a/src/ui/ToolsTabWidget/toolstabwidget.h
+++ b/src/ui/ToolsTabWidget/toolstabwidget.h
@@ -49,6 +49,7 @@ signals:
     void removeStarSignal();
     void setupStarSignal();
     void saveFileSignal();
+    void statusBarInfoChanged(const QString& info);
 
     void setWordWrapSignal(bool checked);
     void setTabReplaceSignal(bool checked);

--- a/src/widgets/filetab.cpp
+++ b/src/widgets/filetab.cpp
@@ -17,6 +17,7 @@ FileTab::FileTab(QWidget* parent, QString path)
     // - - Connects - -
     connect(m_tooltabWidget, &ToolsTabWidget::removeStarSignal, this, &FileTab::removeStar);
     connect(m_tooltabWidget, &ToolsTabWidget::setupStarSignal, this, &FileTab::setupStar);
+    connect(m_tooltabWidget, &ToolsTabWidget::statusBarInfoChanged, this, &FileTab::statusBarInfoChanged);
 
     connect(this, &FileTab::saveFileSignal, m_tooltabWidget, &ToolsTabWidget::saveCurrentTabData);
 

--- a/src/widgets/filetab.h
+++ b/src/widgets/filetab.h
@@ -40,6 +40,8 @@ signals:
     void setTabReplaceSignal(bool checked);
     void setTabWidthSignal(int width);
 
+    void statusBarInfoChanged(const QString& info);
+
 };
 
 #endif // FILETAB_H


### PR DESCRIPTION
## Summary

Implements the StatusBar feature requested in #73. The status bar at the bottom of the IDE window now displays context-aware information depending on which tool tab is active:

**Code Editor:**
- Line number and column number (e.g. `Ln 42, Col 15`)
- Detected programming language based on file extension (C, C++, Python, Rust, Assembly, Go, JS, TS, etc.)

**Binary → RAW:**
- Byte address in hexadecimal (e.g. `Addr: 0x1a3f`)
- Byte number in decimal (e.g. `Byte: 6719`)

**Disassembler:**
- Address of the selected instruction (e.g. `Addr: 0x00401000`)
- Instruction number in the listing (e.g. `Instr: #42`)

## How it works

A `statusBarInfoChanged(const QString&)` signal is added to the `ToolTab` base class and `FormatPage` base class. Each tool tab emits this signal when the cursor moves. The signal propagates through the widget hierarchy:

```
ToolTab → ToolsTabWidget → FileTab → FilesTabWidget → IDEWindow (QStatusBar)
```

Key design decisions:
- **Only the active tool tab's signal is forwarded** — `ToolsTabWidget` filters emissions by `currentWidget()` to prevent background tabs from overwriting the status bar
- **Language detection is computed once** in `setFile()` and cached, not on every keystroke
- **Status bar is cleared** when switching or closing file tabs to avoid stale information
- **Public `cursorLine()` / `cursorColumn()` API** added to `CustomCodeEditor` to avoid accessing private internals

## Files changed

| File | Change |
|------|--------|
| `ToolTab.h` | Added `statusBarInfoChanged` signal |
| `FormatPage.h` | Added `statusBarInfoChanged` signal |
| `CustomCodeEditor.h/.cpp` | Added public `cursorLine()`, `cursorColumn()` |
| `codeeditortab.h/.cpp` | Emits line/col/language on cursor move |
| `rawpage.cpp` | Emits byte address on cursor move |
| `disassemblertab.cpp` | Emits instruction address on cursor move |
| `binarytab.cpp` | Forwards signal from format pages |
| `toolstabwidget.h/.cpp` | Forwards signal (filtered by active tab) |
| `filetab.h/.cpp` | Forwards signal |
| `filestabwidget.h/.cpp` | Forwards signal + clears on tab switch/close |
| `idewindow.cpp` | Connects signal to `QStatusBar::showMessage()` |

## Test plan

- [ ] Open a source file → status bar shows `Ln 1, Col 1    C++` (or appropriate language)
- [ ] Move cursor in code editor → line/col updates in real time
- [ ] Switch to Binary tab → status bar shows `Addr: 0x0    Byte: 0`
- [ ] Click around in hex view → address updates
- [ ] Switch to Disassembler tab, run disassembly → status bar shows instruction address
- [ ] Switch between file tabs → status bar clears and updates for new file
- [ ] Close all file tabs → status bar is empty

Closes #73