### PR TITLE
Fix: support older OS in release build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,11 +16,16 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os:
+          # mainstream OS versions - standard for dev
+          - ubuntu-24.04
+          - macos-15
+          - windows-2025
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+
 
       - name: Install Qt (Windows)
         if: runner.os == 'Windows'
@@ -43,14 +48,16 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y libgl1-mesa-dev libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-render-util0 libxcb-xinerama0 libxcb-cursor0
 
+
       - name: Configure CMake (Windows)
         if: runner.os == 'Windows'
         shell: pwsh
         run: cmake -B build -S src -DCMAKE_BUILD_TYPE=Release -G "Visual Studio 17 2022"
-      
+
       - name: Configure CMake (Linux/macOS)
         if: runner.os != 'Windows'
         run: cmake -B build -S src -DCMAKE_BUILD_TYPE=Release
+
 
       - name: Build
         run: cmake --build build --config Release --parallel

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Build and Release
+name: Build, Test and Release
 
 on:
   push:
@@ -16,14 +16,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
         include:
-          - os: ubuntu-latest
+          # older versions of OS are used for wider accessibility
+          # if they stop being compatible with newer OS versions - update them
+          - os: ubuntu-22.04
             artifact_name: cremniy-linux-${{ github.ref_name }}
-          - os: windows-latest
-            artifact_name: cremniy-windows-${{ github.ref_name }}
-          - os: macos-latest
+          - os: macos-14
             artifact_name: cremniy-macos-${{ github.ref_name }}
+          - os: windows-2022
+            artifact_name: cremniy-windows-${{ github.ref_name }}
 
     steps:
       - name: Checkout code
@@ -36,7 +37,7 @@ jobs:
           version: '6.8.3'
           arch: 'win64_msvc2022_64'
           cache: true
-      
+
       - name: Install Qt (Linux/macOS)
         if: runner.os != 'Windows'
         uses: jurplel/install-qt-action@v3
@@ -62,7 +63,7 @@ jobs:
         if: runner.os == 'Windows'
         shell: pwsh
         run: cmake -B build -S src -DCMAKE_BUILD_TYPE=Release -G "Visual Studio 17 2022"
-      
+
       - name: Configure CMake (Linux/macOS)
         if: runner.os != 'Windows'
         run: cmake -B build -S src -DCMAKE_BUILD_TYPE=Release
@@ -88,7 +89,7 @@ jobs:
             --icon-file cremniy.png \
             --plugin qt \
             --output appimage
-          mv Cremniy-*.AppImage ${{ matrix.artifact_name }}.AppImage || mv cremniy-*.AppImage ${{ matrix.artifact_name }}.AppImage
+          mv Cremniy-*.AppImage ${{ matrix.artifact_name }}.AppImage
 
       - name: Package (Windows)
         if: runner.os == 'Windows'
@@ -108,6 +109,8 @@ jobs:
           mkdir -p package
           cp -r build/cremniy.app package/
           macdeployqt package/cremniy.app
+          codesign --remove-signature package/cremniy.app
+          codesign --force --deep --sign - package/cremniy.app
           cd package
           tar -czf ../${{ matrix.artifact_name }}.tar.gz cremniy.app
 
@@ -121,10 +124,67 @@ jobs:
             ${{ matrix.artifact_name }}.AppImage
           if-no-files-found: error
 
+  test:
+    needs: build
+    name: Test on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # newer OS versions - test if they are compatible with older OS builds
+          - os: ubuntu-24.04
+            artifact_name: cremniy-linux-${{ github.ref_name }}
+          - os: macos-15
+            artifact_name: cremniy-macos-${{ github.ref_name }}
+          - os: windows-2025
+            artifact_name: cremniy-windows-${{ github.ref_name }}
+
+    steps:
+      - name: Get executables
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ matrix.artifact_name }}
+          path: artifact
+
+
+      - name: Test executable (Linux)
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libgl1-mesa-dev libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-render-util0 libxcb-xinerama0 libxcb-cursor0 libfuse2 file imagemagick
+
+          chmod +x ./artifact/${{ matrix.artifact_name }}.AppImage
+          xvfb-run ./artifact/${{ matrix.artifact_name }}.AppImage &
+          sleep 3
+          pkill cremniy
+        # pkill must fail if application failed to start (i.e. already died)
+
+      - name: Test executable (macOS)
+        if: runner.os == 'macOS'
+        run: |
+          tar xvf ./artifact/${{ matrix.artifact_name }}.tar.gz
+          ./cremniy.app/Contents/MacOS/cremniy &
+          sleep 3
+          pkill cremniy
+
+      - name: Test executable (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          Expand-Archive -Path "artifact\${{ matrix.artifact_name }}.zip" -DestinationPath artifact
+          $p = Start-Process -FilePath "artifact\cremniy.exe" -PassThru
+          Start-Sleep -Seconds 3
+          if ($p.HasExited) {
+            throw "Process exited early (code: $($p.ExitCode))"
+          }
+          Stop-Process -Id $p.Id
+
+
   release:
     name: Create Release
-    needs: build
-    runs-on: ubuntu-latest
+    needs: test
+    runs-on: ubuntu-24.04
     if: startsWith(github.ref, 'refs/tags/')
     permissions:
       contents: write


### PR DESCRIPTION
I tried to run latest release (specifically [this one](https://github.com/munirov/cremniy/releases/tag/v0.2.0-unstable.3)) on Linux and MacOS, but it failed to start on both systems.

### Linux — Ubuntu 22.04
AppImage failed to find release's version of glibc (2.38) on my system:
```sh
./cremniy-linux.AppImage       

./cremniy-linux.AppImage: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.38' not found (required by /tmp/.mount_cremnicjoEpm/usr/bin/../lib/libxkbcommon.so.0)
./cremniy-linux.AppImage: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.38' not found (required by /tmp/.mount_cremnicjoEpm/usr/bin/../lib/libglib-2.0.so.0)
./cremniy-linux.AppImage: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.38' not found (required by /tmp/.mount_cremnicjoEpm/usr/bin/../lib/libdbus-1.so.3)
./cremniy-linux.AppImage: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.38' not found (required by /tmp/.mount_cremnicjoEpm/usr/bin/../lib/libsystemd.so.0)
./cremniy-linux.AppImage: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.38' not found (required by /tmp/.mount_cremnicjoEpm/usr/bin/../lib/libcap.so.2)
./cremniy-linux.AppImage: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.38' not found (required by /tmp/.mount_cremnicjoEpm/usr/bin/../lib/libgcrypt.so.20)
```

My system, Ubuntu 22.04, has older version of glibc (2.35):
```
ldd --version

ldd (Ubuntu GLIBC 2.35-0ubuntu3.11) 2.35
Copyright (C) 2022 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
Written by Roland McGrath and Ulrich Drepper.
```

glibc is a fundamental library which cannot be upgraded just by `sudo apt upgrade glibc` — newer glibc versions require kernel upgrade

### MacOS — Sonoma (14)
App failed to start:
<img width="282" height="264" alt="image" src="https://github.com/user-attachments/assets/633e97eb-5323-42e7-8b53-b1d3f828f00e" />

Indeed, application's version of SDK is:
```sh
vtool -show-build Cremniy.app/Contents/MacOS/cremniy

Cremniy.app/Contents/MacOS/cremniy:
Load command 11
      cmd LC_BUILD_VERSION
  cmdsize 32
 platform MACOS
    minos 15.0
      sdk 15.5
   ntools 1
     tool LD
  version 1167.5
```
meanwhile my Sonoma 14 has this characteristics:
```sh
sw_vers

ProductName:    macOS
ProductVersion:    14.4
BuildVersion:    23E214
```

## Why to support it?
1. This systems are still relevant:
    - MacOS 14 (Sonoma) — EoL [fall 2026](https://support-en.wd.com/app/answers/detailweb/a_id/50816/~/apple-macos-end-of-support) (not that much, but still)
    - Ubuntu 22.04 — EoL [May 2027](https://ubuntu.com/about/release-cycle?product=ubuntu&release=ubuntu&version=22.04+LTS)

2. New users which fail to install release would *unlikely* bother upgrading their system. I think we should provide maximum accessibility for users, because growing active user base is important

---

That's why I've changed CI/CD the following way:
1. Set fixed runner OS version everywhere to avoid implicit versions conflict
2. In `release.yml` use older versions to build `cremniy` from
3. To validate build on newer OS versions I just extract build artifact and run its binary. If any dependencies are missing, it will fail to start.

## Result
1. Now AppImage release is runnable on Ubuntu 22.04
2. MacOS build is runnable on MacOS Sonoma 14

You can check updated build artifacts here https://github.com/niki-gor/cremniy/releases/tag/v000.000.000