### PR TITLE
fix: refactoring logic for finding a path to create a folder or file

### DIFF
--- a/src/widgets/filetreepanel.cpp
+++ b/src/widgets/filetreepanel.cpp
@@ -98,7 +98,9 @@ void FileTreePanel::setupConnections() {
 }
 
 QString FileTreePanel::currentPath() const {
-    return m_fileModel->filePath(getSourceIndex());
+    const auto path = m_fileModel->filePath(getSourceIndex());
+    if (path.isEmpty()) return m_root_path;
+    return path;
 }
 
 void FileTreePanel::open() {
@@ -123,10 +125,11 @@ void FileTreePanel::remove() const {
 }
 
 QModelIndex FileTreePanel::getSourceIndex() const{
-    const QModelIndex idx = m_treeView->currentIndex();
+    const QModelIndexList selected = m_treeView->selectionModel()->selectedIndexes();
+    if (selected.isEmpty()) return {};
+    const QModelIndex idx = selected.first();
     if (!idx.isValid()) return {};
-    const QModelIndex srcIdx = m_proxy->mapToSource(idx);
-    return srcIdx;
+    return m_proxy->mapToSource(idx);
 }
 
 void FileTreePanel::showMenu(const QPoint& point) const {

--- a/src/widgets/filetreepanel.h
+++ b/src/widgets/filetreepanel.h
@@ -43,6 +43,6 @@ private:
     QAction* m_rename{};
     QAction* m_delete{};
 
-    const QString& m_root_path;
+    const QString m_root_path;
 };
 #endif // FILETREEPANEL_H


### PR DESCRIPTION
## Fix file/folder creation for empty directory

Fixed an issue where creating a file or folder in an empty directory would incorrectly resolve the path to the last selected item instead of the current directory.

### Problem
`QTreeView::currentIndex()` does not reset when clicking on an empty area it keeps returning the last selected element. This caused the creation dialog to target the wrong path.

### Solution
Switch to using `selectionModel()->selectedIndexes()` instead of `currentIndex()`, so that clicking on an empty area correctly returns an invalid index and falls back to the root path.

```cpp
QModelIndex FileTreePanel::getSourceIndex() const {
    const QModelIndexList selected = m_treeView->selectionModel()->selectedIndexes();
    if (selected.isEmpty()) return {};
    const QModelIndex idx = selected.first();
    if (!idx.isValid()) return {};
    return m_proxy->mapToSource(idx);
}
```