### PR TITLE
Bump sccache to version 0.0.10 and update CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,13 +5,13 @@ on:
     branches: [ main, dev ]
     paths:
       - 'src/**'
-      - '.github/workflows/**'
+      - '.github/workflows/ci.yml'
       
   pull_request:
     branches: [ main, dev ]
     paths:
       - 'src/**'
-      - '.github/workflows/**'
+      - '.github/workflows/ci.yml'
 
 permissions:
   contents: read
@@ -30,7 +30,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup sccache
-        uses: mozilla-actions/sccache-action@v0.0.9
+        uses: mozilla-actions/sccache-action@v0.0.10
 
       - name: Install Qt (Windows)
         if: runner.os == 'Windows'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup sccache
-        uses: mozilla-actions/sccache-action@v0.0.9
+        uses: mozilla-actions/sccache-action@v0.0.10
 
       - name: Install Qt (Windows)
         if: runner.os == 'Windows'


### PR DESCRIPTION
Обновлен action sccache до 0.0.10, изменен путь для таргета ci